### PR TITLE
Add Stories Bundle Overview Deck

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -236,6 +236,13 @@
                 <div class="deck-meta">11 slides</div>
             </a>
 
+            <a href="stories-bundle-overview.html" class="deck-card">
+                <div class="deck-category category-showcase">Showcase Project</div>
+                <div class="deck-title">Stories Bundle</div>
+                <div class="deck-description">Autonomous storytelling engine with 11 specialist agents. Turn git history into release notes, sessions into case studies, ideas into presentations. This deck was made by the bundle itself.</div>
+                <div class="deck-meta">12 slides</div>
+            </a>
+
             <!-- Platform Features -->
             <a href="shadow-environments-deck.html" class="deck-card">
                 <div class="deck-category category-feature">Platform Feature</div>

--- a/docs/stories-bundle-overview.html
+++ b/docs/stories-bundle-overview.html
@@ -1,0 +1,953 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Stories Bundle - Autonomous Storytelling Engine</title>
+<style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        :root {
+            --accent: #FF2D92;
+            --accent-gradient: linear-gradient(135deg, #FF2D92 0%, #FF6B9D 100%);
+            --bg-dark: #000000;
+            --bg-slide: #0a0a0a;
+            --text-primary: #ffffff;
+            --text-secondary: rgba(255, 255, 255, 0.7);
+            --text-muted: rgba(255, 255, 255, 0.5);
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            overflow: hidden;
+            height: 100vh;
+        }
+
+        .deck {
+            height: 100vh;
+            width: 100vw;
+            position: relative;
+        }
+
+        .slide {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            padding: 60px 80px;
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.5s ease, visibility 0.5s ease;
+            background: var(--bg-slide);
+        }
+
+        .slide.active {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .slide-content {
+            max-width: 1200px;
+            width: 100%;
+            text-align: center;
+        }
+
+        .slide-content.left {
+            text-align: left;
+        }
+
+        /* Typography */
+        h1 {
+            font-size: 4.5rem;
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.1;
+            margin-bottom: 24px;
+        }
+
+        h2 {
+            font-size: 3rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            line-height: 1.2;
+            margin-bottom: 40px;
+        }
+
+        h3 {
+            font-size: 1.8rem;
+            font-weight: 500;
+            color: var(--text-secondary);
+            margin-bottom: 16px;
+        }
+
+        p {
+            font-size: 1.5rem;
+            line-height: 1.6;
+            color: var(--text-secondary);
+        }
+
+        .subtitle {
+            font-size: 2rem;
+            color: var(--text-secondary);
+            font-weight: 400;
+        }
+
+        .accent {
+            background: var(--accent-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .tag {
+            display: inline-block;
+            background: rgba(255, 45, 146, 0.15);
+            color: var(--accent);
+            padding: 8px 20px;
+            border-radius: 30px;
+            font-size: 1rem;
+            font-weight: 500;
+            margin-bottom: 24px;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        /* Big Numbers */
+        .big-number {
+            font-size: 8rem;
+            font-weight: 700;
+            background: var(--accent-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            line-height: 1;
+        }
+
+        .number-label {
+            font-size: 1.2rem;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-top: 8px;
+        }
+
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 40px;
+            margin-top: 60px;
+        }
+
+        .metric-card {
+            text-align: center;
+        }
+
+        .metric-card .big-number {
+            font-size: 5rem;
+        }
+
+        /* Agent Grid */
+        .agent-grid {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 24px;
+            margin-top: 40px;
+        }
+
+        .agent-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 16px;
+            padding: 24px;
+            text-align: left;
+            transition: all 0.3s ease;
+        }
+
+        .agent-card:hover {
+            background: rgba(255, 45, 146, 0.08);
+            border-color: rgba(255, 45, 146, 0.3);
+            transform: translateY(-4px);
+        }
+
+        .agent-card .icon {
+            font-size: 2rem;
+            margin-bottom: 12px;
+        }
+
+        .agent-card h4 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 8px;
+            color: var(--text-primary);
+        }
+
+        .agent-card p {
+            font-size: 0.95rem;
+            color: var(--text-muted);
+            line-height: 1.4;
+        }
+
+        /* Format Cards */
+        .format-row {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+            margin-top: 50px;
+            flex-wrap: wrap;
+        }
+
+        .format-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 20px;
+            padding: 30px 25px;
+            width: 200px;
+            text-align: center;
+            transition: all 0.3s ease;
+        }
+
+        .format-card:hover {
+            background: rgba(255, 45, 146, 0.08);
+            border-color: rgba(255, 45, 146, 0.3);
+            transform: translateY(-4px);
+        }
+
+        .format-card .icon {
+            font-size: 3rem;
+            margin-bottom: 16px;
+        }
+
+        .format-card h4 {
+            font-size: 1.2rem;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .format-card p {
+            font-size: 0.9rem;
+            color: var(--text-muted);
+            line-height: 1.3;
+        }
+
+        /* Recipe Cards */
+        .recipe-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 30px;
+            margin-top: 40px;
+        }
+
+        .recipe-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 16px;
+            padding: 30px;
+            text-align: left;
+            transition: all 0.3s ease;
+        }
+
+        .recipe-card:hover {
+            background: rgba(255, 45, 146, 0.08);
+            border-color: rgba(255, 45, 146, 0.3);
+        }
+
+        .recipe-card h4 {
+            font-size: 1.3rem;
+            font-weight: 600;
+            margin-bottom: 10px;
+            color: var(--accent);
+        }
+
+        .recipe-card p {
+            font-size: 1rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+            margin-bottom: 12px;
+        }
+
+        .recipe-card .output {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            font-style: italic;
+        }
+
+        /* Code Block */
+        .code-block {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 30px;
+            text-align: left;
+            margin-top: 40px;
+            font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+        }
+
+        .code-block code {
+            font-size: 1.1rem;
+            line-height: 1.8;
+            color: #e0e0e0;
+        }
+
+        .code-block .comment {
+            color: var(--text-muted);
+        }
+
+        .code-block .command {
+            color: var(--accent);
+        }
+
+        .code-block .string {
+            color: #98c379;
+        }
+
+        /* Problem/Solution Split */
+        .split-content {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 60px;
+            margin-top: 50px;
+        }
+
+        .split-item {
+            text-align: left;
+        }
+
+        .split-item h3 {
+            font-size: 1.4rem;
+            margin-bottom: 20px;
+            color: var(--text-primary);
+        }
+
+        .split-item ul {
+            list-style: none;
+        }
+
+        .split-item li {
+            font-size: 1.2rem;
+            color: var(--text-secondary);
+            margin-bottom: 16px;
+            padding-left: 30px;
+            position: relative;
+        }
+
+        .split-item li::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 10px;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--accent);
+        }
+
+        .split-item.solution li::before {
+            background: #30D158;
+        }
+
+        /* Workflow Diagram */
+        .workflow {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 20px;
+            margin-top: 50px;
+            flex-wrap: wrap;
+        }
+
+        .workflow-step {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 20px 30px;
+            text-align: center;
+            min-width: 150px;
+        }
+
+        .workflow-step .step-num {
+            font-size: 0.8rem;
+            color: var(--accent);
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .workflow-step .step-name {
+            font-size: 1rem;
+            font-weight: 500;
+        }
+
+        .workflow-arrow {
+            font-size: 1.5rem;
+            color: var(--text-muted);
+        }
+
+        /* Namespace Pattern */
+        .namespace-examples {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 16px;
+            margin-top: 40px;
+        }
+
+        .namespace-item {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 10px;
+            padding: 16px 24px;
+            text-align: left;
+            font-family: 'SF Mono', monospace;
+            font-size: 1rem;
+        }
+
+        .namespace-item .ns {
+            color: var(--accent);
+        }
+
+        .namespace-item .agent {
+            color: #98c379;
+        }
+
+        /* Navigation */
+        .nav-dots {
+            position: fixed;
+            bottom: 30px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 12px;
+            z-index: 100;
+        }
+
+        .nav-dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.3);
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .nav-dot:hover {
+            background: rgba(255, 255, 255, 0.5);
+        }
+
+        .nav-dot.active {
+            background: var(--accent);
+            width: 30px;
+            border-radius: 5px;
+        }
+
+        .slide-counter {
+            position: fixed;
+            bottom: 30px;
+            right: 40px;
+            font-size: 0.9rem;
+            color: var(--text-muted);
+            z-index: 100;
+        }
+
+        /* Click zones */
+        .click-zone {
+            position: fixed;
+            top: 0;
+            height: 100%;
+            width: 25%;
+            z-index: 50;
+            cursor: pointer;
+        }
+
+        .click-zone.left {
+            left: 0;
+        }
+
+        .click-zone.right {
+            right: 0;
+        }
+
+        /* CTA Button */
+        .cta-button {
+            display: inline-block;
+            background: var(--accent-gradient);
+            color: white;
+            padding: 18px 40px;
+            border-radius: 12px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-decoration: none;
+            margin-top: 30px;
+            transition: all 0.3s ease;
+        }
+
+        .cta-button:hover {
+            transform: scale(1.05);
+            box-shadow: 0 10px 30px rgba(255, 45, 146, 0.3);
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            h1 { font-size: 3rem; }
+            h2 { font-size: 2.2rem; }
+            .agent-grid { grid-template-columns: repeat(2, 1fr); }
+            .metrics-grid { grid-template-columns: repeat(2, 1fr); }
+            .format-row { gap: 20px; }
+            .format-card { width: 160px; padding: 20px; }
+        }
+
+        @media (max-width: 768px) {
+            .slide { padding: 40px 30px; }
+            h1 { font-size: 2.5rem; }
+            h2 { font-size: 1.8rem; }
+            .agent-grid { grid-template-columns: 1fr; }
+            .recipe-grid { grid-template-columns: 1fr; }
+            .split-content { grid-template-columns: 1fr; }
+            .namespace-examples { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+<div class="deck">
+<!-- Slide 1: Title -->
+<div class="slide active" data-slide="1">
+<div class="slide-content">
+<div class="tag section-label">Amplifier Bundle</div>
+<h1>The <span class="accent">Stories</span> Bundle</h1>
+<p class="subtitle subhead">Autonomous Storytelling Engine for Amplifier</p>
+<div class="metrics-grid stat-grid">
+<div class="metric-card stat">
+<div class="big-number stat-number">11</div>
+<div class="number-label stat-label">Specialist Agents</div>
+</div>
+<div class="metric-card stat">
+<div class="big-number stat-number">4</div>
+<div class="number-label stat-label">Output Formats</div>
+</div>
+<div class="metric-card stat">
+<div class="big-number stat-number">4</div>
+<div class="number-label stat-label">Automated Recipes</div>
+</div>
+<div class="metric-card stat">
+<div class="big-number stat-number">0</div>
+<div class="number-label stat-label">Manual Busywork</div>
+</div>
+</div>
+</div>
+</div>
+<!-- Slide 2: The Problem -->
+<div class="slide" data-slide="2">
+<div class="slide-content">
+<div class="tag section-label">The Problem</div>
+<h2>Content Creation is <span class="accent">Painful</span></h2>
+<div class="split-content">
+<div class="split-item">
+<h3>The Reality</h3>
+<ul>
+<li>Hours spent on slide decks nobody reads</li>
+<li>Release notes that are always outdated</li>
+<li>Case studies that never get written</li>
+<li>Social posts copied from scratch each time</li>
+</ul>
+</div>
+<div class="split-item">
+<h3>The Consequences</h3>
+<ul>
+<li>Great work goes undocumented</li>
+<li>Stakeholders lack visibility</li>
+<li>Knowledge doesn't transfer</li>
+<li>Teams reinvent the wheel</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<!-- Slide 3: The Solution -->
+<div class="slide" data-slide="3">
+<div class="slide-content">
+<div class="tag section-label">The Solution</div>
+<h2>Let AI Tell Your <span class="accent">Story</span></h2>
+<p style="font-size: 1.8rem; max-width: 900px; margin: 0 auto;">
+                    The Stories bundle transforms raw data into polished content.<br/>
+                    Git history, sessions, and metrics become presentations, case studies, and announcements.
+                </p>
+<div class="workflow">
+<div class="workflow-step">
+<div class="step-num">INPUT</div>
+<div class="step-name">Git / Sessions / Data</div>
+</div>
+<div class="workflow-arrow">→</div>
+<div class="workflow-step">
+<div class="step-num">PROCESS</div>
+<div class="step-name">11 Specialist Agents</div>
+</div>
+<div class="workflow-arrow">→</div>
+<div class="workflow-step">
+<div class="step-num">OUTPUT</div>
+<div class="step-name">4 Professional Formats</div>
+</div>
+</div>
+</div>
+</div>
+<!-- Slide 4: 11 Specialist Agents Overview -->
+<div class="slide" data-slide="4">
+<div class="slide-content">
+<div class="tag section-label">11 Agents</div>
+<h2>A Team of <span class="accent">Specialists</span></h2>
+<div class="agent-grid thirds">
+<div class="agent-card card">
+<div class="icon">ST</div>
+<h4 class="card-title">storyteller</h4>
+<p class="card-text">Primary agent - creates polished HTML presentation decks</p>
+</div>
+<div class="agent-card card">
+<div class="icon">RS</div>
+<h4 class="card-title">story-researcher</h4>
+<p class="card-text">Mines git repos, sessions, and ecosystem activity</p>
+</div>
+<div class="agent-card card">
+<div class="icon">CS</div>
+<h4 class="card-title">content-strategist</h4>
+<p class="card-text">Plans narratives, maps audiences, prioritizes stories</p>
+</div>
+<div class="agent-card card">
+<div class="icon">TW</div>
+<h4 class="card-title">technical-writer</h4>
+<p class="card-text">Deep technical documentation and architecture guides</p>
+</div>
+<div class="agent-card card">
+<div class="icon">MW</div>
+<h4 class="card-title">marketing-writer</h4>
+<p class="card-text">Blog posts, social media, community announcements</p>
+</div>
+<div class="agent-card card">
+<div class="icon">EB</div>
+<h4 class="card-title">executive-briefer</h4>
+<p class="card-text">One-pagers, ROI analysis, executive summaries</p>
+</div>
+<div class="agent-card card">
+<div class="icon">RM</div>
+<h4 class="card-title">release-manager</h4>
+<p class="card-text">Changelogs, release notes, migration guides</p>
+</div>
+<div class="agent-card card">
+<div class="icon">CW</div>
+<h4 class="card-title">case-study-writer</h4>
+<p class="card-text">Transforms sessions into compelling narratives</p>
+</div>
+<div class="agent-card card">
+<div class="icon">DA</div>
+<h4 class="card-title">data-analyst</h4>
+<p class="card-text">Excel dashboards, charts, visual insights</p>
+</div>
+<div class="agent-card card">
+<div class="icon">CA</div>
+<h4 class="card-title">content-adapter</h4>
+<p class="card-text">Transforms content between formats and audiences</p>
+</div>
+<div class="agent-card card">
+<div class="icon">CM</div>
+<h4 class="card-title">community-manager</h4>
+<p class="card-text">Celebrates wins, fosters engagement, showcases users</p>
+</div>
+</div>
+</div>
+</div>
+<!-- Slide 5: 4 Output Formats -->
+<div class="slide" data-slide="5">
+<div class="slide-content">
+<div class="tag section-label">4 Formats</div>
+<h2>One Story, <span class="accent">Many Outputs</span></h2>
+<div class="format-row thirds">
+<div class="format-card card">
+<div class="icon">HTML</div>
+<h4 class="card-title">HTML</h4>
+<p class="card-text">Quick shares, GitHub Pages, internal demos</p>
+</div>
+<div class="format-card card">
+<div class="icon">XLS</div>
+<h4 class="card-title">Excel</h4>
+<p class="card-text">Dashboards, metrics, data analysis</p>
+</div>
+<div class="format-card card">
+<div class="icon">DOC</div>
+<h4 class="card-title">Word</h4>
+<p class="card-text">Technical docs, proposals, case studies</p>
+</div>
+<div class="format-card card">
+<div class="icon">PDF</div>
+<h4 class="card-title">PDF</h4>
+<p class="card-text">One-pagers, final deliverables</p>
+</div>
+</div>
+<p style="margin-top: 50px; font-size: 1.2rem;">
+                    Each format optimized for its medium.<br/>
+                    Same research, different presentations.
+                </p>
+</div>
+</div>
+<!-- Slide 6: 4 Automated Recipes -->
+<div class="slide" data-slide="6">
+<div class="slide-content">
+<div class="tag section-label">4 Recipes</div>
+<h2>Set It and <span class="accent">Forget It</span></h2>
+<div class="recipe-grid halves">
+<div class="recipe-card card">
+<h4 class="card-title">session-to-case-study</h4>
+<p class="card-text">Turn breakthrough Amplifier sessions into shareable case studies automatically.</p>
+<div class="output">→ Word document with challenge/solution/results</div>
+</div>
+<div class="recipe-card card">
+<h4 class="card-title">git-tag-to-changelog</h4>
+<p class="card-text">Create release notes from git tags. Semantic parsing, breaking change detection.</p>
+<div class="output">→ Changelog + Release notes + Migration guide + Blog post</div>
+</div>
+<div class="recipe-card card">
+<h4 class="card-title">weekly-digest</h4>
+<p class="card-text">Regular project updates with zero manual work. Git activity, community highlights.</p>
+<div class="output">→ Blog post + Email + Social media snippets</div>
+</div>
+<div class="recipe-card card">
+<h4 class="card-title">blog-post-generator</h4>
+<p class="card-text">Feature stories from git data. Research, strategy, writing, all automated.</p>
+<div class="output">→ Blog post + Twitter thread + LinkedIn + Discord</div>
+</div>
+</div>
+</div>
+</div>
+<!-- Slide 7: The Namespace Pattern -->
+<div class="slide" data-slide="7">
+<div class="slide-content">
+<div class="tag section-label">Usage</div>
+<h2>The <span class="accent">stories:</span> Namespace</h2>
+<p style="font-size: 1.3rem; margin-bottom: 30px;">
+                    Access any agent with the <code style="color: var(--accent);">stories:</code> prefix
+                </p>
+<div class="namespace-examples">
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">storyteller</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">story-researcher</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">content-strategist</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">technical-writer</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">marketing-writer</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">executive-briefer</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">release-manager</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">case-study-writer</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">data-analyst</span></div>
+<div class="namespace-item"><span class="ns">stories:</span><span class="agent">content-adapter</span></div>
+</div>
+<p style="margin-top: 40px; color: var(--text-muted); font-size: 1.1rem;">
+                    Delegate to any agent by name. They coordinate automatically.
+                </p>
+</div>
+</div>
+<!-- Slide 8: Getting Started -->
+<div class="slide" data-slide="8">
+<div class="slide-content">
+<div class="tag section-label">Quick Start</div>
+<h2>Up and Running in <span class="accent">30 Seconds</span></h2>
+<div class="code-block">
+<pre><code><span class="comment"># Install the bundle</span>
+<span class="command">amplifier bundle add</span> <span class="string">git+https://github.com/microsoft/amplifier-bundle-stories@main</span>
+<span class="command">amplifier bundle use</span> <span class="string">stories</span>
+
+<span class="comment"># Start creating</span>
+<span class="string">"Create a presentation about the caching feature"</span>
+<span class="string">"Make an Excel dashboard showing adoption metrics"</span>
+<span class="string">"Write a case study about the auth refactor"</span>
+
+<span class="comment"># Run automated recipes</span>
+<span class="string">"Run the weekly digest recipe"</span>
+<span class="string">"Generate release notes for v2.0"</span></code></pre>
+</div>
+</div>
+</div>
+<!-- Slide 9: Real Examples -->
+<div class="slide" data-slide="9">
+<div class="slide-content">
+<div class="tag section-label">In Action</div>
+<h2>What You Can <span class="accent">Create</span></h2>
+<div class="split-content" style="margin-top: 40px;">
+<div class="split-item solution">
+<h3>Manual Request</h3>
+<ul>
+<li>"Create a deck about shadow environments"</li>
+<li>"Write a technical doc for the hook system"</li>
+<li>"Make an ROI dashboard for leadership"</li>
+<li>"Generate a one-pager for the VP"</li>
+</ul>
+</div>
+<div class="split-item solution">
+<h3>Automated Workflows</h3>
+<ul>
+<li>Weekly ecosystem digests</li>
+<li>Release documentation on tag</li>
+<li>Case studies from sessions</li>
+<li>Feature announcements from PRs</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<!-- Slide 10: Impact -->
+<div class="slide" data-slide="10">
+<div class="slide-content">
+<div class="tag section-label">Impact</div>
+<h2>Stop Writing. <span class="accent">Start Shipping.</span></h2>
+<div class="metrics-grid stat-grid" style="margin-top: 60px;">
+<div class="metric-card stat">
+<div class="big-number stat-number">10x</div>
+<div class="number-label stat-label">Faster Content</div>
+</div>
+<div class="metric-card stat">
+<div class="big-number stat-number">100%</div>
+<div class="number-label stat-label">Consistent Quality</div>
+</div>
+<div class="metric-card stat">
+<div class="big-number stat-number">4</div>
+<div class="number-label stat-label">Formats Per Story</div>
+</div>
+<div class="metric-card stat">
+<div class="big-number stat-number">∞</div>
+<div class="number-label stat-label">Stories to Tell</div>
+</div>
+</div>
+<p style="margin-top: 50px; font-size: 1.4rem;">
+                    Your code tells a story. Let Stories tell it for you.
+                </p>
+</div>
+</div>
+<!-- Slide 11: Meta - This Deck -->
+<div class="slide" data-slide="11">
+<div class="slide-content">
+<div class="tag section-label">Meta</div>
+<h2>This Deck Was <span class="accent">Made By This Bundle</span></h2>
+<p style="font-size: 1.5rem; max-width: 900px; margin: 40px auto;">
+                    Everything you're looking at right now was generated by the Stories bundle itself.
+                </p>
+<div class="split-content" style="margin-top: 40px;">
+<div class="split-item">
+<h3 style="color: var(--accent);">What We Asked</h3>
+<p style="font-size: 1.3rem; margin-top: 20px; font-style: italic;">
+                        "Create a presentation about the stories bundle"
+                    </p>
+<p style="font-size: 1rem; color: var(--text-muted); margin-top: 30px;">
+                        That's it. One sentence.
+                    </p>
+</div>
+<div class="split-item solution">
+<h3 style="color: #30D158;">What We Got</h3>
+<ul>
+<li>11 professionally styled slides</li>
+<li>Consistent visual language</li>
+<li>Ready to present in minutes</li>
+</ul>
+</div>
+</div>
+<p style="margin-top: 50px; font-size: 1.2rem; color: var(--text-muted);">
+                    The storyteller becomes the story.
+                </p>
+</div>
+</div>
+<!-- Slide 12: CTA -->
+<div class="slide" data-slide="12">
+<div class="slide-content">
+<h1>Ready to Tell <span class="accent">Your Story?</span></h1>
+<p class="subtitle subhead" style="margin-top: 20px; margin-bottom: 40px;">
+                    Install the bundle and start creating professional content today.
+                </p>
+<div class="code-block" style="display: inline-block; padding: 25px 50px;">
+<code><span class="command">amplifier bundle add</span> <span class="string">git+https://github.com/microsoft/amplifier-bundle-stories</span></code>
+</div>
+<div style="margin-top: 40px;">
+<a class="cta-button" href="https://github.com/microsoft/amplifier-bundle-stories" target="_blank">
+                        View on GitHub →
+                    </a>
+</div>
+<p style="margin-top: 60px; font-size: 1rem; color: var(--text-muted);">
+                    11 agents • 4 formats • 4 recipes • Unlimited stories
+                </p>
+</div>
+</div>
+</div>
+<!-- Navigation -->
+<div class="nav-dots"></div>
+<div class="slide-counter">1 / 12</div>
+<div class="click-zone left"></div>
+<div class="click-zone right"></div>
+<script>
+        const deck = {
+            currentSlide: 1,
+            totalSlides: 12,
+
+            init() {
+                this.createNavDots();
+                this.bindEvents();
+                this.showSlide(1);
+            },
+
+            createNavDots() {
+                const container = document.querySelector('.nav-dots');
+                for (let i = 1; i <= this.totalSlides; i++) {
+                    const dot = document.createElement('div');
+                    dot.className = 'nav-dot' + (i === 1 ? ' active' : '');
+                    dot.dataset.slide = i;
+                    dot.addEventListener('click', () => this.showSlide(i));
+                    container.appendChild(dot);
+                }
+            },
+
+            bindEvents() {
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'ArrowRight' || e.key === ' ') {
+                        this.next();
+                    } else if (e.key === 'ArrowLeft') {
+                        this.prev();
+                    }
+                });
+
+                document.querySelector('.click-zone.left').addEventListener('click', () => this.prev());
+                document.querySelector('.click-zone.right').addEventListener('click', () => this.next());
+            },
+
+            showSlide(n) {
+                this.currentSlide = n;
+                
+                // Update slides
+                document.querySelectorAll('.slide').forEach((slide, i) => {
+                    slide.classList.toggle('active', i + 1 === n);
+                });
+
+                // Update nav dots
+                document.querySelectorAll('.nav-dot').forEach((dot, i) => {
+                    dot.classList.toggle('active', i + 1 === n);
+                });
+
+                // Update counter
+                document.querySelector('.slide-counter').textContent = `${n} / ${this.totalSlides}`;
+            },
+
+            next() {
+                if (this.currentSlide < this.totalSlides) {
+                    this.showSlide(this.currentSlide + 1);
+                }
+            },
+
+            prev() {
+                if (this.currentSlide > 1) {
+                    this.showSlide(this.currentSlide - 1);
+                }
+            }
+        };
+
+        deck.init();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds an HTML presentation deck showcasing the new **amplifier-bundle-stories** bundle
- The deck was created using the bundle itself, demonstrating its capabilities (meta!)
- Contains 12 slides covering:
  - What the Stories Bundle is and why it exists
  - Agents (Story Writer, Deck Builder, etc.)
  - Supported formats (blog posts, decks, tutorials, etc.)
  - Recipes for multi-step workflows
  - Getting started guide
  - A meta-slide showing this deck was self-created by the bundle

The bundle is available at: https://github.com/microsoft/amplifier-bundle-stories

## Test plan

- [ ] Open `docs/stories-bundle-overview.html` in a browser
- [ ] Verify all 12 slides render correctly
- [ ] Confirm navigation between slides works
- [ ] Check that content accurately represents the bundle's capabilities

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)