### PR TITLE
Add M365 hackathon presentation deck to staging

### DIFF
--- a/staging/m365-hackathon-deck.html
+++ b/staging/m365-hackathon-deck.html
@@ -1,0 +1,664 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>M365 + Amplifier Hackathon: What We Learned</title>
+    <style>
+        :root {
+            --accent-color: #FF8A65;
+            --accent-dim: rgba(255, 138, 101, 0.15);
+            --font-headline: clamp(32px, 8vw, 72px);
+            --font-medium-headline: clamp(24px, 5vw, 48px);
+            --font-subhead: clamp(16px, 3vw, 28px);
+            --font-big-number: clamp(48px, 15vw, 140px);
+            --padding-slide: clamp(20px, 5vw, 80px);
+            --gap-grid: clamp(16px, 3vw, 40px);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, sans-serif;
+            background: #000;
+            color: #fff;
+            overflow: hidden;
+            overscroll-behavior: none;
+        }
+
+        .slide {
+            display: none;
+            width: 100vw;
+            min-height: 100vh;
+            min-height: 100dvh;
+            padding: clamp(60px, 10vw, 120px) var(--padding-slide) clamp(80px, 12vw, 100px);
+            flex-direction: column;
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        .slide.active {
+            display: flex;
+        }
+
+        .center {
+            text-align: center;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .section-label {
+            font-size: clamp(11px, 1.5vw, 14px);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 3px;
+            color: var(--accent-color);
+            margin-bottom: 16px;
+        }
+
+        .headline {
+            font-size: var(--font-headline);
+            font-weight: 700;
+            letter-spacing: clamp(-1px, -0.03em, -2px);
+            line-height: 1.1;
+            margin-bottom: 24px;
+        }
+
+        .medium-headline {
+            font-size: var(--font-medium-headline);
+            font-weight: 600;
+            letter-spacing: -1px;
+            line-height: 1.2;
+            margin-bottom: 20px;
+        }
+
+        .subhead {
+            font-size: var(--font-subhead);
+            color: rgba(255, 255, 255, 0.7);
+            max-width: 700px;
+            line-height: 1.5;
+        }
+
+        .small-text {
+            font-size: clamp(12px, 1.5vw, 14px);
+            color: rgba(255, 255, 255, 0.4);
+            margin-top: 32px;
+        }
+
+        .big-number {
+            font-size: var(--font-big-number);
+            font-weight: 800;
+            background: linear-gradient(135deg, var(--accent-color) 0%, #FFD54F 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            line-height: 1;
+        }
+
+        .thirds {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+            gap: var(--gap-grid);
+            margin-top: 32px;
+        }
+
+        .halves {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+            gap: var(--gap-grid);
+            margin-top: 32px;
+        }
+
+        .card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: clamp(12px, 2vw, 16px);
+            padding: clamp(20px, 4vw, 32px);
+        }
+
+        .card-title {
+            font-size: clamp(16px, 2.5vw, 20px);
+            font-weight: 600;
+            margin-bottom: 12px;
+            color: var(--accent-color);
+        }
+
+        .card-text {
+            font-size: clamp(14px, 2vw, 16px);
+            color: rgba(255, 255, 255, 0.7);
+            line-height: 1.6;
+        }
+
+        .quote-block {
+            background: var(--accent-dim);
+            border-left: 4px solid var(--accent-color);
+            border-radius: 0 16px 16px 0;
+            padding: clamp(20px, 4vw, 32px);
+            margin: 24px 0;
+            max-width: 900px;
+        }
+
+        .quote-text {
+            font-size: clamp(16px, 2.5vw, 22px);
+            font-style: italic;
+            color: rgba(255, 255, 255, 0.9);
+            line-height: 1.6;
+        }
+
+        .quote-attr {
+            font-size: clamp(12px, 1.5vw, 14px);
+            color: rgba(255, 255, 255, 0.5);
+            margin-top: 16px;
+        }
+
+        .code-block {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 12px;
+            padding: clamp(16px, 3vw, 24px);
+            font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+            font-size: clamp(11px, 1.8vw, 14px);
+            line-height: 1.7;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            margin: 20px 0;
+            max-width: 100%;
+        }
+
+        .code-block .comment { color: rgba(255, 255, 255, 0.4); }
+        .code-block .success { color: #30D158; }
+        .code-block .info { color: #64D2FF; }
+        .code-block .highlight { color: var(--accent-color); }
+        .code-block .string { color: #FFD54F; }
+
+        .velocity-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(200px, 100%), 1fr));
+            gap: var(--gap-grid);
+            margin-top: 40px;
+            width: 100%;
+            max-width: 900px;
+        }
+
+        .velocity-stat {
+            text-align: center;
+            padding: 20px;
+        }
+
+        .velocity-number {
+            font-size: clamp(48px, 12vw, 96px);
+            font-weight: 800;
+            background: linear-gradient(135deg, var(--accent-color) 0%, #FFD54F 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            line-height: 1;
+        }
+
+        .velocity-label {
+            font-size: clamp(14px, 2vw, 18px);
+            color: rgba(255, 255, 255, 0.6);
+            margin-top: 8px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .feature-list {
+            list-style: none;
+            margin-top: 24px;
+        }
+
+        .feature-list li {
+            font-size: clamp(16px, 2.5vw, 20px);
+            color: rgba(255, 255, 255, 0.8);
+            padding: 12px 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+            display: flex;
+            align-items: flex-start;
+            gap: 16px;
+        }
+
+        .feature-list li:last-child {
+            border-bottom: none;
+        }
+
+        .feature-list .icon {
+            color: var(--accent-color);
+            font-size: clamp(18px, 2.5vw, 22px);
+        }
+
+        .timeline-item {
+            display: flex;
+            gap: 20px;
+            margin-bottom: 24px;
+            align-items: flex-start;
+        }
+
+        .timeline-marker {
+            width: 12px;
+            height: 12px;
+            background: var(--accent-color);
+            border-radius: 50%;
+            margin-top: 6px;
+            flex-shrink: 0;
+        }
+
+        .timeline-content {
+            flex: 1;
+        }
+
+        .timeline-title {
+            font-size: clamp(16px, 2.5vw, 20px);
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .timeline-desc {
+            font-size: clamp(14px, 2vw, 16px);
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .highlight-text {
+            color: var(--accent-color);
+            font-weight: 600;
+        }
+
+        .dim-text {
+            color: rgba(255, 255, 255, 0.5);
+        }
+
+        .badge {
+            display: inline-block;
+            background: var(--accent-dim);
+            color: var(--accent-color);
+            padding: 6px 14px;
+            border-radius: 20px;
+            font-size: clamp(12px, 1.5vw, 14px);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-bottom: 20px;
+        }
+
+        .use-case-card {
+            background: linear-gradient(135deg, rgba(255, 138, 101, 0.1) 0%, rgba(255, 213, 79, 0.05) 100%);
+            border: 1px solid rgba(255, 138, 101, 0.2);
+            border-radius: 16px;
+            padding: clamp(24px, 4vw, 36px);
+        }
+
+        .use-case-card .card-title {
+            font-size: clamp(18px, 3vw, 24px);
+            margin-bottom: 16px;
+        }
+
+        /* Navigation */
+        .nav {
+            position: fixed;
+            bottom: 30px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 8px;
+            z-index: 100;
+        }
+
+        .nav-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.3);
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .nav-dot.active {
+            background: var(--accent-color);
+            transform: scale(1.3);
+        }
+
+        .slide-counter {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.4);
+            font-variant-numeric: tabular-nums;
+            z-index: 100;
+        }
+
+        /* Landscape mobile adjustments */
+        @media (max-height: 500px) and (orientation: landscape) {
+            .slide {
+                padding: 20px var(--padding-slide) 60px;
+            }
+            .slide.center {
+                justify-content: flex-start;
+                padding-top: 40px;
+            }
+        }
+
+        /* Reduced motion */
+        @media (prefers-reduced-motion: reduce) {
+            .slide, .slide *, .nav-dot {
+                animation: none !important;
+                transition: none !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Slide 1: Title -->
+    <div class="slide active center">
+        <div class="section-label">M365 + Amplifier Hackathon</div>
+        <h1 class="headline">We Severely Underestimate<br>What AI Agents Can Do</h1>
+        <p class="subhead">A story about discovery, surprise, and the future of human-AI collaboration</p>
+        <div class="small-text">January 2026</div>
+    </div>
+
+    <!-- Slide 2: The Challenge -->
+    <div class="slide center">
+        <div class="section-label">The Challenge</div>
+        <h2 class="headline">Can Amplifier build its<br>own M365 integration?</h2>
+        <p class="subhead">No existing code. No documentation. No hand-holding.<br>Just a test tenant and a simple instruction.</p>
+    </div>
+
+    <!-- Slide 3: The Prompt -->
+    <div class="slide">
+        <div class="section-label">The Setup</div>
+        <h2 class="medium-headline">One prompt. One hour. Zero prep.</h2>
+        <div class="quote-block">
+            <div class="quote-text">"I just got a M365 test tenant for you! You don't have the code/tools/etc to do it, so you'll have to start by building yourself those things."</div>
+            <div class="quote-attr">The only instruction given to Amplifier</div>
+        </div>
+        <div class="halves">
+            <div class="card">
+                <div class="card-title">What Users Provided</div>
+                <div class="card-text">Tenant ID, Client ID, and copy-pasted permissions. That's it.</div>
+            </div>
+            <div class="card">
+                <div class="card-title">What Users Did NOT Provide</div>
+                <div class="card-text">Architecture decisions, code, API knowledge, authentication logic, error handling...</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 4: What Happened -->
+    <div class="slide">
+        <div class="section-label">What Happened</div>
+        <h2 class="medium-headline">Amplifier took over</h2>
+        <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+                <div class="timeline-title">Designed the architecture</div>
+                <div class="timeline-desc">Decided on a Python module structure with 11+ source files</div>
+            </div>
+        </div>
+        <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+                <div class="timeline-title">Built 3-tier authentication</div>
+                <div class="timeline-desc">ClientSecretCredential → DeviceCodeCredential → DefaultAzureCredential fallback chain</div>
+            </div>
+        </div>
+        <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+                <div class="timeline-title">Created operation modules</div>
+                <div class="timeline-desc">email_send, email_read, calendar_list_events, user_list, sharepoint_search, teams_send_message</div>
+            </div>
+        </div>
+        <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+                <div class="timeline-title">Wrote specialized agents</div>
+                <div class="timeline-desc">m365-admin.md and m365-productivity.md with distinct personas</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 5: The Takeover Moment -->
+    <div class="slide">
+        <div class="section-label">The Turning Point</div>
+        <h2 class="medium-headline">Autonomous adaptation</h2>
+        <p class="subhead" style="margin-bottom: 24px;">When the user provided different permissions than expected, Amplifier didn't ask what to do. It pivoted.</p>
+        <div class="quote-block">
+            <div class="quote-text">"Actually, I need to add Teams operations! The current implementation has Email/Calendar but the permissions granted are for Teams/Chat/Files/Tasks."</div>
+            <div class="quote-attr">Amplifier, noticing the mismatch and adapting without being asked</div>
+        </div>
+        <div class="quote-block" style="background: rgba(48, 209, 88, 0.1); border-left-color: #30D158;">
+            <div class="quote-text">"Actually, I realized you can do this for me... let me know when you have a device code for me to try"</div>
+            <div class="quote-attr">User's realization that they could step back and let Amplifier lead</div>
+        </div>
+    </div>
+
+    <!-- Slide 6: Zero Technical Depth -->
+    <div class="slide center">
+        <div class="section-label">Key Insight</div>
+        <h2 class="headline">Zero technical depth<br>required</h2>
+        <p class="subhead">Participants just followed instructions Amplifier gave them.<br>Navigate to Azure portal. Grant these permissions. Click here. Paste this.</p>
+        <div class="velocity-grid" style="margin-top: 48px;">
+            <div class="velocity-stat">
+                <div class="velocity-number">0</div>
+                <div class="velocity-label">Lines of code written by users</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">0</div>
+                <div class="velocity-label">API docs consulted</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 7: 100% Success Rate -->
+    <div class="slide center">
+        <div class="badge">Repeatable</div>
+        <div class="big-number">100%</div>
+        <h2 class="medium-headline" style="margin-top: 20px;">Success rate</h2>
+        <div class="halves" style="max-width: 800px; margin-top: 40px;">
+            <div class="card" style="text-align: center;">
+                <div class="card-title">Week 1</div>
+                <div class="card-text">Small group mini-hackathon<br>Everyone succeeded</div>
+            </div>
+            <div class="card" style="text-align: center;">
+                <div class="card-title">Week 2</div>
+                <div class="card-text">Much larger group<br>Same 100% success rate</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 8: Week Two - Going Deeper -->
+    <div class="slide">
+        <div class="section-label">Extended Exploration</div>
+        <h2 class="medium-headline">Week two: Going deeper</h2>
+        <p class="subhead" style="margin-bottom: 32px;">With working M365 integration, participants explored what's actually possible.</p>
+        <div class="thirds">
+            <div class="card">
+                <div class="card-title">5 Agent Users</div>
+                <div class="card-text">Created in M365: amplifier-agent-1 through -5, each with Teams license</div>
+            </div>
+            <div class="card">
+                <div class="card-title">"AI Agents" Team</div>
+                <div class="card-text">8 specialized channels: Handoffs, Task Coordination, Alerts, Decisions, File Exchange, Logs</div>
+            </div>
+            <div class="card">
+                <div class="card-title">Polling Daemon</div>
+                <div class="card-text">Python service that watches for @mentions and routes to Amplifier for responses</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 9: Agent Users -->
+    <div class="slide center">
+        <div class="section-label">A New Paradigm</div>
+        <h2 class="headline">Agent users are<br>real M365 citizens</h2>
+        <p class="subhead">Not API consumers. Actual team members.</p>
+        <ul class="feature-list" style="max-width: 700px; margin-top: 40px; text-align: left;">
+            <li><span class="icon">@</span> Mention them in Teams like colleagues</li>
+            <li><span class="icon">💬</span> They respond in conversation threads</li>
+            <li><span class="icon">📧</span> They have email addresses and mailboxes</li>
+            <li><span class="icon">🤝</span> They can be added to any team or channel</li>
+        </ul>
+    </div>
+
+    <!-- Slide 10: IT WORKED Moment -->
+    <div class="slide">
+        <div class="section-label">The Breakthrough</div>
+        <h2 class="medium-headline">The "IT WORKED" moment</h2>
+        <div class="code-block"><span class="info">Processing Teams message mentioning Amplifier Agent 1 from MOD Administrator</span>
+<span class="highlight">Created new session teams:acad129f-a50b-4a3a...</span>
+<span class="dim-text">HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"</span>
+<span class="success">Sent Teams reply successfully</span>
+<span class="success">Agent Amplifier Agent 1 responded to Teams message</span></div>
+        <div class="code-block"><span class="info">📧 Checking for new emails for Amplifier Agent 1...</span>
+<span class="highlight">Found 1 unread email(s)</span>
+Processing email from MOD Administrator
+Agent generated response (length: 847)
+<span class="success">✅ Reply sent successfully!</span></div>
+    </div>
+
+    <!-- Slide 11: Autonomous Bug Fixing -->
+    <div class="slide">
+        <div class="section-label">Self-Correction</div>
+        <h2 class="medium-headline">Autonomous problem solving</h2>
+        <p class="subhead" style="margin-bottom: 24px;">When Teams split "@Amplifier Agent 1" into 3 separate mentions, Amplifier diagnosed and fixed it without being asked.</p>
+        <div class="quote-block">
+            <div class="quote-text">"I see the issue! Teams split your @mention into 3 separate mentions... The daemon needs to check the <span class="highlight-text">user ID</span> in the mention, not just the display name."</div>
+            <div class="quote-attr">Amplifier, diagnosing a subtle Teams API behavior</div>
+        </div>
+        <div class="card" style="margin-top: 24px; max-width: 600px;">
+            <div class="card-title">Then it just... fixed it</div>
+            <div class="card-text">Modified the code to use user ID matching. Tested it. Confirmed it worked. Moved on.</div>
+        </div>
+    </div>
+
+    <!-- Slide 12: Future Use Cases -->
+    <div class="slide">
+        <div class="section-label">What's Next</div>
+        <h2 class="medium-headline">The future is multi-agent</h2>
+        <div class="thirds" style="margin-top: 24px;">
+            <div class="use-case-card">
+                <div class="card-title">Personal Uplevel</div>
+                <div class="card-text">My agent does work for me autonomously. Monitors my inbox. Drafts responses. Schedules meetings. Summarizes threads I missed.</div>
+            </div>
+            <div class="use-case-card">
+                <div class="card-title">Agent Proxies</div>
+                <div class="card-text">"Have my agent talk to Sam's agent" - they might collaborate via Teams messages, shared docs, or structured handoffs.</div>
+            </div>
+            <div class="use-case-card">
+                <div class="card-title">Device Coordination</div>
+                <div class="card-text">Amplifier instances on different machines (home, office, server) coordinating work via M365 as the communication backbone.</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 13: What We Built -->
+    <div class="slide center">
+        <div class="section-label">Development Velocity</div>
+        <h2 class="medium-headline">What Amplifier built autonomously</h2>
+        <div class="velocity-grid">
+            <div class="velocity-stat">
+                <div class="velocity-number">11+</div>
+                <div class="velocity-label">Source Files</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">6</div>
+                <div class="velocity-label">API Operations</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">3</div>
+                <div class="velocity-label">Auth Methods</div>
+            </div>
+        </div>
+        <div class="velocity-grid" style="margin-top: 20px;">
+            <div class="velocity-stat">
+                <div class="velocity-number">5</div>
+                <div class="velocity-label">Agent Users</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">8</div>
+                <div class="velocity-label">Teams Channels</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">1</div>
+                <div class="velocity-label">Polling Daemon</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 14: The Takeaway -->
+    <div class="slide center">
+        <div class="section-label">The Takeaway</div>
+        <h1 class="headline">We severely underestimate<br>what AI agents can do</h1>
+        <p class="subhead" style="margin-top: 32px;">The bottleneck isn't the AI's capability.<br>It's our imagination about what to ask for.</p>
+        <div class="small-text" style="margin-top: 48px;">M365 + Amplifier Hackathon • January 2026</div>
+    </div>
+
+    <!-- Navigation -->
+    <div class="nav" id="nav"></div>
+    <div class="slide-counter" id="counter"></div>
+
+    <script>
+        const slides = document.querySelectorAll('.slide');
+        let currentSlide = 0;
+
+        function showSlide(n) {
+            slides[currentSlide].classList.remove('active');
+            currentSlide = (n + slides.length) % slides.length;
+            slides[currentSlide].classList.add('active');
+            updateNav();
+        }
+
+        function updateNav() {
+            const nav = document.getElementById('nav');
+            const counter = document.getElementById('counter');
+            nav.innerHTML = '';
+            slides.forEach((_, i) => {
+                const dot = document.createElement('div');
+                dot.className = 'nav-dot' + (i === currentSlide ? ' active' : '');
+                dot.onclick = (e) => { e.stopPropagation(); showSlide(i); };
+                nav.appendChild(dot);
+            });
+            counter.textContent = `${currentSlide + 1} / ${slides.length}`;
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); showSlide(currentSlide + 1); }
+            if (e.key === 'ArrowLeft') { e.preventDefault(); showSlide(currentSlide - 1); }
+        });
+
+        // Click navigation
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('.nav')) return;
+            if (e.clientX > window.innerWidth / 2) showSlide(currentSlide + 1);
+            else showSlide(currentSlide - 1);
+        });
+
+        // Touch/swipe navigation
+        let touchStartX = 0;
+        let touchEndX = 0;
+        const SWIPE_THRESHOLD = 50;
+
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        }, { passive: true });
+
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            const diff = touchStartX - touchEndX;
+            if (Math.abs(diff) > SWIPE_THRESHOLD) {
+                if (diff > 0) showSlide(currentSlide + 1);
+                else showSlide(currentSlide - 1);
+            }
+        }, { passive: true });
+
+        updateNav();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds HTML presentation deck documenting the M365 + Amplifier hackathon exploration
- Brian led 1-hour mini-hackathons where participants gave Amplifier access to M365 dev/test tenants
- Amplifier built its own tools to connect (OAuth2, Graph API, Teams integration)
- 100% success rate across two hackathons, zero technical depth required
- Demonstrates "we severely underestimate what AI agents can do"

The deck has 14 slides covering the journey from "build yourself the tools" to working Teams integration with agent users.

## Test plan

- [x] HTML file renders correctly in browser
- [x] File placed in staging/ directory as requested

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)