### PR TITLE
feat: add "400 Tabs to 100" story deck

### DIFF
--- a/staging/400-tabs-to-100.html
+++ b/staging/400-tabs-to-100.html
@@ -1,0 +1,913 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>400 Tabs to 100: How Amplifier Manages Your Browser</title>
+    <style>
+        :root {
+            --accent: #34D399;
+            --accent-dim: rgba(52, 211, 153, 0.15);
+            --accent-glow: rgba(52, 211, 153, 0.3);
+            --chaos: #FF453A;
+            --chaos-dim: rgba(255, 69, 58, 0.15);
+            --chaos-warm: #FF6B35;
+            --amber: #FBBF24;
+            --font-headline: clamp(32px, 7vw, 68px);
+            --font-medium-headline: clamp(24px, 5vw, 48px);
+            --font-subhead: clamp(16px, 3vw, 28px);
+            --font-body: clamp(14px, 2.2vw, 20px);
+            --font-big-number: clamp(72px, 22vw, 200px);
+            --padding-slide: clamp(20px, 5vw, 80px);
+            --gap-grid: clamp(16px, 3vw, 40px);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, sans-serif;
+            background: #000;
+            color: #fff;
+            overflow: hidden;
+            overscroll-behavior: none;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .slide {
+            display: none;
+            width: 100vw;
+            min-height: 100vh;
+            min-height: 100dvh;
+            padding: clamp(60px, 10vw, 120px) var(--padding-slide) clamp(80px, 12vw, 100px);
+            flex-direction: column;
+            overflow-y: auto;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        .slide.active { display: flex; }
+
+        .slide.center {
+            text-align: center;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .section-label {
+            font-size: clamp(11px, 1.5vw, 14px);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 3px;
+            color: var(--accent);
+            margin-bottom: clamp(12px, 2vw, 24px);
+        }
+
+        .section-label.chaos { color: var(--chaos); }
+
+        .headline {
+            font-size: var(--font-headline);
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.08;
+            margin-bottom: clamp(16px, 3vw, 32px);
+        }
+
+        .medium-headline {
+            font-size: var(--font-medium-headline);
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            line-height: 1.15;
+            margin-bottom: clamp(12px, 2.5vw, 28px);
+        }
+
+        .subhead {
+            font-size: var(--font-subhead);
+            color: rgba(255,255,255,0.6);
+            line-height: 1.5;
+            max-width: 700px;
+        }
+
+        .body-text {
+            font-size: var(--font-body);
+            color: rgba(255,255,255,0.7);
+            line-height: 1.7;
+            max-width: 640px;
+        }
+
+        .big-number {
+            font-size: var(--font-big-number);
+            font-weight: 800;
+            letter-spacing: -0.04em;
+            line-height: 1;
+        }
+
+        .small-text {
+            font-size: clamp(12px, 1.5vw, 15px);
+            color: rgba(255,255,255,0.35);
+            margin-top: clamp(12px, 2vw, 20px);
+        }
+
+        /* Grids */
+        .thirds {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
+            gap: var(--gap-grid);
+            width: 100%;
+            max-width: 1100px;
+            margin-top: clamp(16px, 3vw, 32px);
+        }
+
+        .halves {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
+            gap: var(--gap-grid);
+            width: 100%;
+            max-width: 1100px;
+            margin-top: clamp(16px, 3vw, 32px);
+        }
+
+        .card {
+            background: rgba(255,255,255,0.04);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: clamp(12px, 2vw, 16px);
+            padding: clamp(20px, 4vw, 32px);
+        }
+
+        .card-accent {
+            border-color: rgba(52, 211, 153, 0.2);
+            background: rgba(52, 211, 153, 0.04);
+        }
+
+        .card-chaos {
+            border-color: rgba(255, 69, 58, 0.2);
+            background: rgba(255, 69, 58, 0.04);
+        }
+
+        .card h3 {
+            font-size: clamp(16px, 2.5vw, 22px);
+            font-weight: 600;
+            margin-bottom: 10px;
+            line-height: 1.3;
+        }
+
+        .card p {
+            font-size: clamp(13px, 2vw, 16px);
+            color: rgba(255,255,255,0.55);
+            line-height: 1.6;
+        }
+
+        .card-icon {
+            font-size: clamp(28px, 5vw, 42px);
+            margin-bottom: 12px;
+            display: block;
+        }
+
+        /* Quote styles */
+        .quote-block {
+            background: rgba(255,255,255,0.03);
+            border-left: 3px solid var(--accent);
+            border-radius: 0 12px 12px 0;
+            padding: clamp(20px, 4vw, 36px);
+            margin: clamp(16px, 3vw, 28px) 0;
+            max-width: 800px;
+        }
+
+        .quote-text {
+            font-size: clamp(18px, 3.5vw, 32px);
+            font-weight: 500;
+            font-style: italic;
+            line-height: 1.4;
+            color: rgba(255,255,255,0.9);
+        }
+
+        .quote-attr {
+            font-size: clamp(13px, 2vw, 16px);
+            color: rgba(255,255,255,0.4);
+            margin-top: 12px;
+        }
+
+        /* Code block */
+        .code-block {
+            background: rgba(255,255,255,0.04);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 12px;
+            padding: clamp(16px, 3vw, 24px);
+            font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+            font-size: clamp(12px, 1.8vw, 15px);
+            line-height: 1.7;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            overflow-x: auto;
+            max-width: 800px;
+            margin-top: clamp(12px, 2vw, 20px);
+        }
+
+        .code-green { color: var(--accent); }
+        .code-dim { color: rgba(255,255,255,0.35); }
+        .code-amber { color: var(--amber); }
+
+        /* Flow diagram */
+        .flow {
+            display: flex;
+            align-items: center;
+            gap: clamp(8px, 2vw, 20px);
+            flex-wrap: wrap;
+            justify-content: center;
+            margin: clamp(20px, 4vw, 40px) 0;
+        }
+
+        .flow-step {
+            background: rgba(255,255,255,0.06);
+            border: 1px solid rgba(255,255,255,0.12);
+            border-radius: 12px;
+            padding: clamp(12px, 2vw, 20px) clamp(16px, 3vw, 28px);
+            font-size: clamp(13px, 2vw, 17px);
+            font-weight: 500;
+            text-align: center;
+            white-space: nowrap;
+        }
+
+        .flow-step.highlight {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--accent);
+        }
+
+        .flow-arrow {
+            color: rgba(255,255,255,0.25);
+            font-size: clamp(16px, 2.5vw, 24px);
+        }
+
+        /* Velocity grid */
+        .velocity-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(160px, 100%), 1fr));
+            gap: var(--gap-grid);
+            width: 100%;
+            max-width: 900px;
+            margin-top: clamp(20px, 4vw, 40px);
+        }
+
+        .velocity-stat {
+            text-align: center;
+            padding: clamp(16px, 3vw, 24px);
+        }
+
+        .velocity-number {
+            font-size: clamp(36px, 10vw, 72px);
+            font-weight: 800;
+            letter-spacing: -0.03em;
+            background: linear-gradient(135deg, var(--accent), #06B6D4);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            line-height: 1.1;
+        }
+
+        .velocity-number.chaos-num {
+            background: linear-gradient(135deg, var(--chaos), var(--chaos-warm));
+            -webkit-background-clip: text;
+            background-clip: text;
+        }
+
+        .velocity-label {
+            font-size: clamp(12px, 1.8vw, 15px);
+            color: rgba(255,255,255,0.45);
+            margin-top: 8px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        /* Tab visualization */
+        .tab-field {
+            position: relative;
+            width: 100%;
+            max-width: 900px;
+            height: clamp(200px, 35vw, 360px);
+            margin: clamp(16px, 3vw, 28px) auto;
+            overflow: hidden;
+        }
+
+        .mini-tab {
+            position: absolute;
+            border-radius: 6px;
+            font-size: 8px;
+            overflow: hidden;
+            transition: all 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        /* Comparison */
+        .comparison {
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+            gap: clamp(16px, 3vw, 40px);
+            align-items: center;
+            max-width: 900px;
+            width: 100%;
+            margin-top: clamp(20px, 3vw, 32px);
+        }
+
+        .comparison-side { text-align: center; }
+
+        .comparison-divider {
+            width: 1px;
+            height: 120px;
+            background: rgba(255,255,255,0.1);
+        }
+
+        .comparison-number {
+            font-size: clamp(48px, 14vw, 120px);
+            font-weight: 800;
+            line-height: 1;
+            letter-spacing: -0.04em;
+        }
+
+        .comparison-label {
+            font-size: clamp(13px, 2vw, 17px);
+            color: rgba(255,255,255,0.5);
+            margin-top: 8px;
+        }
+
+        @media (max-width: 600px) {
+            .comparison {
+                grid-template-columns: 1fr;
+                gap: 20px;
+            }
+            .comparison-divider {
+                width: 60%;
+                height: 1px;
+                margin: 0 auto;
+            }
+        }
+
+        /* Highlight span */
+        .hl { color: var(--accent); }
+        .hl-chaos { color: var(--chaos); }
+        .hl-amber { color: var(--amber); }
+        .dim { color: rgba(255,255,255,0.4); }
+
+        /* Feature list */
+        .feature-list {
+            list-style: none;
+            margin-top: clamp(12px, 2vw, 20px);
+            max-width: 700px;
+        }
+
+        .feature-list li {
+            font-size: var(--font-body);
+            color: rgba(255,255,255,0.65);
+            line-height: 1.6;
+            padding: 8px 0;
+            padding-left: 28px;
+            position: relative;
+        }
+
+        .feature-list li::before {
+            content: '';
+            position: absolute;
+            left: 0;
+            top: 16px;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--accent);
+            opacity: 0.6;
+        }
+
+        .feature-list.chaos li::before { background: var(--chaos); }
+
+        /* Strikethrough style */
+        .struck {
+            text-decoration: line-through;
+            color: rgba(255,255,255,0.25);
+        }
+
+        /* Pill / tag */
+        .pill {
+            display: inline-block;
+            padding: 4px 14px;
+            border-radius: 100px;
+            font-size: clamp(11px, 1.5vw, 13px);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .pill-accent {
+            background: var(--accent-dim);
+            color: var(--accent);
+            border: 1px solid rgba(52,211,153,0.3);
+        }
+
+        .pill-chaos {
+            background: var(--chaos-dim);
+            color: var(--chaos);
+            border: 1px solid rgba(255,69,58,0.3);
+        }
+
+        /* Arrow down indicator */
+        .arrow-down {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+            margin: clamp(16px, 3vw, 24px) 0;
+        }
+
+        .arrow-down svg {
+            width: 32px;
+            height: 32px;
+            opacity: 0.3;
+        }
+
+        /* Navigation */
+        .nav {
+            position: fixed;
+            bottom: clamp(16px, 3vw, 24px);
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 8px;
+            z-index: 100;
+            padding: 8px 16px;
+            background: rgba(0,0,0,0.5);
+            backdrop-filter: blur(10px);
+            border-radius: 100px;
+        }
+
+        .nav-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.2);
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .nav-dot.active {
+            background: var(--accent);
+            box-shadow: 0 0 8px rgba(52, 211, 153, 0.4);
+        }
+
+        .nav-dot:hover { background: rgba(255,255,255,0.5); }
+
+        .slide-counter {
+            position: fixed;
+            bottom: clamp(16px, 3vw, 24px);
+            right: clamp(16px, 3vw, 24px);
+            font-size: 12px;
+            color: rgba(255,255,255,0.25);
+            z-index: 100;
+            font-variant-numeric: tabular-nums;
+        }
+
+        /* Landscape mobile */
+        @media (max-height: 500px) and (orientation: landscape) {
+            .slide {
+                padding: 16px var(--padding-slide) 60px;
+            }
+            .slide.center { justify-content: flex-start; padding-top: 32px; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .slide, .slide *, .mini-tab {
+                animation: none !important;
+                transition: none !important;
+            }
+        }
+
+        /* Subtle background texture for certain slides */
+        .bg-grid {
+            background-image:
+                linear-gradient(rgba(255,255,255,0.015) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(255,255,255,0.015) 1px, transparent 1px);
+            background-size: 40px 40px;
+        }
+
+        /* Gradient text */
+        .gradient-text {
+            background: linear-gradient(135deg, var(--accent), #06B6D4);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .gradient-text-chaos {
+            background: linear-gradient(135deg, var(--chaos), var(--chaos-warm));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        /* Terminal color demo */
+        .terminal-colors {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            flex-wrap: wrap;
+            margin-top: 16px;
+        }
+
+        .terminal-tab-demo {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 16px;
+            background: rgba(255,255,255,0.04);
+            border-radius: 8px;
+            font-size: clamp(12px, 1.8vw, 15px);
+        }
+
+        .tab-dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+        }
+
+        .tab-dot.red { background: #FF453A; box-shadow: 0 0 6px rgba(255,69,58,0.5); }
+        .tab-dot.green { background: #34D399; box-shadow: 0 0 6px rgba(52,211,153,0.5); }
+        .tab-dot.amber { background: #FBBF24; box-shadow: 0 0 6px rgba(251,191,36,0.5); }
+        .tab-dot.blue { background: #60A5FA; box-shadow: 0 0 6px rgba(96,165,250,0.5); }
+    </style>
+</head>
+<body>
+
+    <!-- ============ SLIDE 1: TITLE ============ -->
+    <div class="slide active center">
+        <div class="section-label">Amplifier + AppleScript</div>
+        <h1 class="headline" style="max-width: 800px;">
+            <span class="gradient-text-chaos">400</span> Tabs to <span class="gradient-text">100</span>
+        </h1>
+        <p class="subhead" style="margin-top: 8px;">
+            How Amplifier manages your browser &mdash; without anyone telling it how
+        </p>
+        <div class="small-text">A real story about AI reducing cognitive load</div>
+    </div>
+
+    <!-- ============ SLIDE 2: THE PROBLEM ============ -->
+    <div class="slide">
+        <div class="section-label chaos">The Problem</div>
+        <h2 class="headline">You have too many tabs open.</h2>
+        <p class="body-text">
+            Right now. You know it. Everyone knows it. And nobody does anything about it.
+        </p>
+        <div class="thirds" style="margin-top: clamp(24px, 4vw, 40px);">
+            <div class="card card-chaos">
+                <span class="card-icon">🧠</span>
+                <h3>Every tab is a decision you deferred</h3>
+                <p>"Maybe I'll need this later." So you leave it open. Times four hundred.</p>
+            </div>
+            <div class="card card-chaos">
+                <span class="card-icon">📊</span>
+                <h3>Knowledge workers average 25+ tabs</h3>
+                <p>Power users? Easily 100 to 400+. Each one a tiny thread of attention left dangling.</p>
+            </div>
+            <div class="card card-chaos">
+                <span class="card-icon">😤</span>
+                <h3>Closing tabs feels like losing information</h3>
+                <p>So you don't close them. The pile grows. The overwhelm compounds.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ SLIDE 3: ATTENTION DEBT ============ -->
+    <div class="slide center">
+        <div class="section-label chaos">Attention Debt</div>
+        <h2 class="headline" style="max-width: 700px;">
+            Each open tab is a <span class="hl-chaos">micro-anxiety</span> you carry all day
+        </h2>
+        <p class="subhead" style="margin-top: 16px;">
+            Psychologists call it <em>attention residue</em>. Your brain keeps a background thread running for every unfinished task. 400 tabs = 400 background threads in your mind.
+        </p>
+        <div class="small-text">This is not a technology problem. It's a human problem.</div>
+    </div>
+
+    <!-- ============ SLIDE 4: ENTER APPLESCRIPT ============ -->
+    <div class="slide bg-grid">
+        <div class="section-label">The Discovery</div>
+        <h2 class="headline">What if your AI could <span class="hl">see</span> your browser?</h2>
+        <p class="body-text" style="margin-bottom: clamp(16px, 3vw, 28px);">
+            macOS has a hidden superpower called <strong style="color:#fff">AppleScript</strong> &mdash; a way for programs to talk to other programs. Apps choose what to expose: window titles, tab URLs, document contents.
+        </p>
+        <p class="body-text">
+            Microsoft Edge exposes <em>everything</em> about your tabs. And Amplifier has access to the terminal.
+        </p>
+        <div class="flow" style="margin-top: clamp(28px, 5vw, 48px);">
+            <div class="flow-step">You</div>
+            <div class="flow-arrow">→</div>
+            <div class="flow-step highlight">Amplifier</div>
+            <div class="flow-arrow">→</div>
+            <div class="flow-step">bash</div>
+            <div class="flow-arrow">→</div>
+            <div class="flow-step">AppleScript</div>
+            <div class="flow-arrow">→</div>
+            <div class="flow-step" style="border-color: rgba(96,165,250,0.4); color: #60A5FA;">Microsoft Edge</div>
+        </div>
+        <p class="body-text dim" style="text-align: center; margin-top: 16px; max-width: 100%;">
+            Amplifier can read every tab title, URL, and window &mdash; in seconds.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 5: THE KEY INSIGHT ============ -->
+    <div class="slide center">
+        <div class="section-label">Key Insight</div>
+        <h2 class="headline" style="max-width: 780px;">
+            Nobody told Amplifier <em>how</em> to do this.
+        </h2>
+        <p class="subhead" style="margin-top: 12px; max-width: 600px;">
+            Sam just said: <span class="hl">"organize my tabs."</span>
+        </p>
+        <p class="body-text" style="margin-top: 24px; text-align: center; max-width: 600px;">
+            Amplifier figured out on its own that it could use bash to run AppleScript to query Edge. No plugin. No integration. No configuration. It just&hellip; worked it out.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 6: THE BEFORE STATE ============ -->
+    <div class="slide center">
+        <div class="section-label chaos">Before</div>
+        <div class="comparison" style="margin-top: 0;">
+            <div class="comparison-side">
+                <div class="comparison-number gradient-text-chaos">400+</div>
+                <div class="comparison-label">open tabs</div>
+            </div>
+            <div class="comparison-divider"></div>
+            <div class="comparison-side">
+                <div style="font-size: clamp(14px, 2.2vw, 18px); color: rgba(255,255,255,0.5); line-height: 1.7;">
+                    Scattered across multiple windows<br>
+                    Duplicates everywhere<br>
+                    Tabs from weeks ago<br>
+                    No organization at all
+                </div>
+            </div>
+        </div>
+        <p class="body-text dim" style="text-align: center; margin-top: clamp(20px, 4vw, 36px); max-width: 100%;">
+            You know the feeling. You can't even find the tab you need.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 7: THE PROCESS ============ -->
+    <div class="slide">
+        <div class="section-label">What Amplifier Did</div>
+        <h2 class="medium-headline">Read. Group. Clean.</h2>
+        <div class="thirds">
+            <div class="card card-accent">
+                <span class="card-icon" style="font-size: clamp(32px, 6vw, 48px);">1</span>
+                <h3 style="color: var(--accent);">Read every tab</h3>
+                <p>Used AppleScript to extract the title and URL of all 400+ tabs across every Edge window.</p>
+            </div>
+            <div class="card card-accent">
+                <span class="card-icon" style="font-size: clamp(32px, 6vw, 48px);">2</span>
+                <h3 style="color: var(--accent);">Grouped by topic</h3>
+                <p>Organized tabs into categories: work projects, research, reference docs, social media, news, shopping&hellip;</p>
+            </div>
+            <div class="card card-accent">
+                <span class="card-icon" style="font-size: clamp(32px, 6vw, 48px);">3</span>
+                <h3 style="color: var(--accent);">Cleaned the noise</h3>
+                <p>Identified duplicates, stale pages, and tabs that were no longer relevant. Closed them.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ SLIDE 8: THE RESULT ============ -->
+    <div class="slide center">
+        <div class="section-label">After</div>
+        <div class="comparison" style="margin-top: 0;">
+            <div class="comparison-side">
+                <div class="comparison-number" style="color: rgba(255,255,255,0.2);">
+                    <span class="struck" style="color: rgba(255,255,255,0.15);">400+</span>
+                </div>
+                <div class="comparison-label" style="color: rgba(255,255,255,0.2);">before</div>
+            </div>
+            <div class="comparison-divider"></div>
+            <div class="comparison-side">
+                <div class="comparison-number gradient-text">&lt;100</div>
+                <div class="comparison-label">organized, relevant tabs</div>
+            </div>
+        </div>
+        <p class="body-text" style="text-align: center; margin-top: clamp(20px, 4vw, 36px); max-width: 550px;">
+            Just the tabs Sam actually needed. Grouped. Organized. Manageable.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 9: TIME ============ -->
+    <div class="slide center">
+        <div class="section-label">Speed</div>
+        <h2 class="medium-headline" style="color: rgba(255,255,255,0.5);">A human would spend hours doing this.</h2>
+        <div style="margin: clamp(20px, 4vw, 40px) 0;">
+            <div class="big-number gradient-text">Minutes.</div>
+        </div>
+        <p class="body-text" style="text-align: center; max-width: 100%;">
+            Amplifier processed all 400+ tabs, categorized them, identified noise, and cleaned up &mdash; in a single conversation.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 10: ATTENTION MANAGEMENT ============ -->
+    <div class="slide">
+        <div class="section-label">The Vision</div>
+        <h2 class="headline">Attention <span class="hl">management</span>,<br>not attention <span class="hl-chaos">consumption</span>.</h2>
+        <p class="body-text" style="margin-top: clamp(12px, 2vw, 20px);">
+            Most AI products <em>demand</em> your attention. Notifications. Feeds. Alerts. Suggestions. Every app fighting for a piece of your focus.
+        </p>
+        <div class="halves" style="margin-top: clamp(24px, 4vw, 36px);">
+            <div class="card card-chaos">
+                <h3><span class="hl-chaos">Typical AI</span></h3>
+                <ul class="feature-list chaos" style="margin-top: 8px;">
+                    <li>Sends you notifications</li>
+                    <li>Shows you "suggested" content</li>
+                    <li>Interrupts your workflow</li>
+                    <li>Adds to your cognitive load</li>
+                </ul>
+            </div>
+            <div class="card card-accent">
+                <h3><span class="hl">Amplifier</span></h3>
+                <ul class="feature-list" style="margin-top: 8px;">
+                    <li>Reduces your open tabs</li>
+                    <li>Organizes your workspace</li>
+                    <li>Removes mental clutter</li>
+                    <li>Gives your attention back</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ SLIDE 11: GOING FURTHER ============ -->
+    <div class="slide">
+        <div class="section-label">Going Further</div>
+        <h2 class="medium-headline">After browser tabs, the vision expanded:</h2>
+        <h2 class="headline" style="margin-top: 4px;">What about <span class="hl">terminal</span> tabs?</h2>
+        <p class="body-text" style="margin-top: clamp(12px, 2vw, 20px);">
+            Imagine one Amplifier session managing all your terminal sessions. Color-coding them by status:
+        </p>
+        <div class="terminal-colors" style="margin: clamp(20px, 4vw, 36px) 0;">
+            <div class="terminal-tab-demo">
+                <span class="tab-dot red"></span>
+                <span>Needs attention</span>
+            </div>
+            <div class="terminal-tab-demo">
+                <span class="tab-dot amber"></span>
+                <span>Running task</span>
+            </div>
+            <div class="terminal-tab-demo">
+                <span class="tab-dot green"></span>
+                <span>Healthy</span>
+            </div>
+            <div class="terminal-tab-demo">
+                <span class="tab-dot blue"></span>
+                <span>Idle</span>
+            </div>
+        </div>
+        <p class="body-text" style="margin-top: 8px;">
+            <span class="dim">Reality check:</span> Terminal.app exposes limited AppleScript (just tab coloring). Warp terminal doesn't expose AppleScript at all. The capability depends on what apps choose to share.
+        </p>
+        <p class="body-text" style="margin-top: 12px;">
+            But the <strong style="color:#fff">vision</strong> is clear: Amplifier as your <span class="hl">attention orchestrator</span> across every app.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 12: THE REACTION ============ -->
+    <div class="slide center">
+        <div class="section-label">The Reaction</div>
+        <div class="quote-block" style="text-align: left;">
+            <div class="quote-text">
+                "You built an AI-powered Shortcuts app which Apple has not been able to build yet."
+            </div>
+            <div class="quote-attr">&mdash; Audience member</div>
+        </div>
+        <div class="quote-block" style="text-align: left; border-left-color: var(--accent);">
+            <div class="quote-text" style="font-size: clamp(16px, 3vw, 26px);">
+                "We didn't <em>build</em> it &mdash; Amplifier took advantage of it <span class="hl">dynamically</span>, on its own."
+            </div>
+            <div class="quote-attr">&mdash; Brian, Amplifier creator</div>
+        </div>
+    </div>
+
+    <!-- ============ SLIDE 13: DYNAMIC NOT HARDCODED ============ -->
+    <div class="slide">
+        <div class="section-label">The Differentiator</div>
+        <h2 class="headline" style="max-width: 700px;">Dynamic discovery, not hardcoded integrations.</h2>
+        <div class="halves" style="margin-top: clamp(24px, 4vw, 36px);">
+            <div class="card" style="border-color: rgba(255,255,255,0.1);">
+                <h3 style="color: rgba(255,255,255,0.4);">Apple Shortcuts</h3>
+                <p style="margin-top: 8px;">You manually build every workflow. Drag blocks. Configure actions. For every app. Every time.</p>
+                <div class="pill pill-chaos" style="margin-top: 16px;">Manual</div>
+            </div>
+            <div class="card card-accent">
+                <h3 style="color: var(--accent);">Amplifier</h3>
+                <p style="margin-top: 8px;">You describe what you want. Amplifier discovers the tools available and figures out how to accomplish it.</p>
+                <div class="pill pill-accent" style="margin-top: 16px;">Dynamic</div>
+            </div>
+        </div>
+        <p class="body-text dim" style="margin-top: clamp(20px, 3vw, 28px);">
+            No plugins to install. No integrations to configure. If an app exposes capabilities via AppleScript, Amplifier can use them.
+        </p>
+    </div>
+
+    <!-- ============ SLIDE 14: THE PATTERN ============ -->
+    <div class="slide">
+        <div class="section-label">Beyond Tabs</div>
+        <h2 class="headline">This pattern extends <span class="hl">everywhere</span>.</h2>
+        <p class="body-text">AppleScript + Amplifier = dynamic automation of any macOS app that exposes capabilities.</p>
+        <div class="thirds" style="margin-top: clamp(24px, 4vw, 36px);">
+            <div class="card">
+                <span class="card-icon">📁</span>
+                <h3>File organization</h3>
+                <p>Sort your Downloads folder, organize project files, archive old documents.</p>
+            </div>
+            <div class="card">
+                <span class="card-icon">📧</span>
+                <h3>App management</h3>
+                <p>Query Mail, Calendar, Notes &mdash; any app that exposes an AppleScript dictionary.</p>
+            </div>
+            <div class="card">
+                <span class="card-icon">⚡</span>
+                <h3>Workflow automation</h3>
+                <p>Chain actions across apps. Move data between tools. Automate repetitive sequences.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============ SLIDE 15: CLOSING ============ -->
+    <div class="slide center">
+        <div class="section-label">What This Means</div>
+        <h2 class="headline" style="max-width: 700px;">
+            Your AI should <span class="hl">reduce</span> your cognitive load.
+        </h2>
+        <p class="subhead" style="margin-top: 16px; max-width: 600px;">
+            Not add to it.
+        </p>
+        <p class="body-text" style="margin-top: clamp(24px, 4vw, 40px); text-align: center; max-width: 560px;">
+            400 tabs down to 100 is just the beginning. The future is AI that manages your digital environment &mdash; so you can focus on the work that actually matters.
+        </p>
+        <div class="small-text" style="margin-top: clamp(28px, 5vw, 48px);">
+            <span class="hl" style="font-size: clamp(14px, 2vw, 18px); letter-spacing: 1px;">amplifier</span>
+            <span class="dim" style="margin-left: 8px;">— attention management for the real world</span>
+        </div>
+    </div>
+
+    <!-- Navigation -->
+    <div class="nav" id="nav"></div>
+    <div class="slide-counter" id="counter"></div>
+
+    <script>
+        const slides = document.querySelectorAll('.slide');
+        let currentSlide = 0;
+
+        function showSlide(n) {
+            slides[currentSlide].classList.remove('active');
+            currentSlide = (n + slides.length) % slides.length;
+            slides[currentSlide].classList.add('active');
+            slides[currentSlide].scrollTop = 0;
+            updateNav();
+        }
+
+        function updateNav() {
+            const nav = document.getElementById('nav');
+            const counter = document.getElementById('counter');
+            nav.innerHTML = '';
+            slides.forEach((_, i) => {
+                const dot = document.createElement('div');
+                dot.className = 'nav-dot' + (i === currentSlide ? ' active' : '');
+                dot.onclick = (e) => { e.stopPropagation(); showSlide(i); };
+                nav.appendChild(dot);
+            });
+            counter.textContent = `${currentSlide + 1} / ${slides.length}`;
+        }
+
+        // Keyboard
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); showSlide(currentSlide + 1); }
+            if (e.key === 'ArrowLeft') { e.preventDefault(); showSlide(currentSlide - 1); }
+            if (e.key === 'Home') { e.preventDefault(); showSlide(0); }
+            if (e.key === 'End') { e.preventDefault(); showSlide(slides.length - 1); }
+        });
+
+        // Click
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('.nav')) return;
+            if (e.target.closest('a')) return;
+            if (e.clientX > window.innerWidth / 2) showSlide(currentSlide + 1);
+            else showSlide(currentSlide - 1);
+        });
+
+        // Touch / swipe
+        let touchStartX = 0;
+        let touchEndX = 0;
+        const SWIPE_THRESHOLD = 50;
+
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        }, { passive: true });
+
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            const diff = touchStartX - touchEndX;
+            if (Math.abs(diff) > SWIPE_THRESHOLD) {
+                if (diff > 0) showSlide(currentSlide + 1);
+                else showSlide(currentSlide - 1);
+            }
+        }, { passive: true });
+
+        updateNav();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a 15-slide HTML presentation deck: **"400 Tabs to 100"** — the story of how Amplifier manages browser tabs via AppleScript
- Placed in `staging/` for review before promotion to `docs/`
- Non-technical friendly narrative covering the full journey

## What the deck covers

1. **The Discovery** — realizing AppleScript could control Edge tabs
2. **The Demo** — Amplifier dynamically discovering and using AppleScript capabilities through bash to organize 400+ Edge tabs down to under 100
3. **Attention Management Vision** — tabs as a proxy for focus, and how AI can help manage cognitive load
4. **Terminal Tab Exploration** — extending the concept beyond browsers
5. **Audience Reactions** — real responses to the live demo

## Details

- Self-contained HTML with embedded CSS and JS (no external dependencies)
- Keyboard navigation (arrow keys) and responsive layout
- ~35KB single file

## Test plan

- [x] File renders correctly in browser
- [x] All 15 slides navigate properly
- [x] No external dependencies or broken assets

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)