### PR TITLE
feat: add withamplifier.com developers page story deck

### DIFF
--- a/presentations/withamplifier-developers-page-story.html
+++ b/presentations/withamplifier-developers-page-story.html
@@ -1,0 +1,1029 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Five Days to Ship &mdash; Building the withamplifier.com Developers Page</title>
+    <style>
+        :root {
+            --accent: #FF375F;
+            --accent-dim: rgba(255, 55, 95, 0.15);
+            --accent-glow: rgba(255, 55, 95, 0.3);
+            --bg: #000;
+            --surface: rgba(255,255,255,0.05);
+            --border: rgba(255,255,255,0.1);
+            --text: #fff;
+            --text-dim: rgba(255,255,255,0.5);
+            --text-mid: rgba(255,255,255,0.7);
+            --green: #30D158;
+            --blue: #0A84FF;
+            --purple: #BF5AF2;
+            --teal: #64D2FF;
+            --orange: #FF9F0A;
+
+            --fs-hero: clamp(36px, 10vw, 72px);
+            --fs-h1: clamp(28px, 6vw, 48px);
+            --fs-h2: clamp(22px, 4vw, 32px);
+            --fs-h3: clamp(18px, 3vw, 24px);
+            --fs-body: clamp(14px, 2vw, 16px);
+            --fs-small: clamp(12px, 1.8vw, 14px);
+            --fs-code: clamp(11px, 1.6vw, 14px);
+            --fs-big-number: clamp(48px, 14vw, 120px);
+
+            --space-xs: clamp(8px, 1.5vw, 12px);
+            --space-sm: clamp(12px, 2vw, 16px);
+            --space-md: clamp(16px, 3vw, 24px);
+            --space-lg: clamp(24px, 4vw, 40px);
+            --space-xl: clamp(32px, 6vw, 60px);
+
+            --radius-sm: clamp(8px, 1vw, 12px);
+            --radius-md: clamp(12px, 1.5vw, 16px);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            overflow: hidden;
+            overscroll-behavior: none;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .slide {
+            display: none;
+            width: 100vw;
+            min-height: 100vh;
+            min-height: 100dvh;
+            padding: clamp(60px, 10vw, 120px) clamp(20px, 5vw, 80px) clamp(80px, 12vw, 100px);
+            flex-direction: column;
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        .slide.active { display: flex; }
+
+        .slide.center {
+            text-align: center;
+            align-items: center;
+            justify-content: center;
+        }
+
+        @media (max-height: 500px) and (orientation: landscape) {
+            .slide { padding: 16px clamp(20px, 5vw, 80px) 60px; }
+            .slide.center { justify-content: flex-start; padding-top: 24px; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .slide, .slide * {
+                animation: none !important;
+                transition: none !important;
+            }
+        }
+
+        /* Typography */
+        .section-label {
+            font-size: var(--fs-small);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: var(--accent);
+            margin-bottom: var(--space-sm);
+        }
+
+        .headline {
+            font-size: var(--fs-hero);
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1.05;
+            margin-bottom: var(--space-md);
+        }
+
+        .medium-headline {
+            font-size: var(--fs-h1);
+            font-weight: 700;
+            letter-spacing: -0.02em;
+            line-height: 1.1;
+            margin-bottom: var(--space-md);
+        }
+
+        .small-headline {
+            font-size: var(--fs-h2);
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            line-height: 1.2;
+            margin-bottom: var(--space-sm);
+        }
+
+        .subhead {
+            font-size: var(--fs-h3);
+            color: var(--text-mid);
+            line-height: 1.5;
+            max-width: min(700px, 90vw);
+        }
+
+        .body-text {
+            font-size: var(--fs-body);
+            color: var(--text-mid);
+            line-height: 1.7;
+            max-width: min(680px, 90vw);
+        }
+
+        .small-text {
+            font-size: var(--fs-small);
+            color: var(--text-dim);
+        }
+
+        .accent { color: var(--accent); }
+        .green { color: var(--green); }
+        .blue { color: var(--blue); }
+        .purple { color: var(--purple); }
+        .teal { color: var(--teal); }
+        .orange { color: var(--orange); }
+        .dim { color: var(--text-dim); }
+        .mid { color: var(--text-mid); }
+
+        /* Layouts */
+        .thirds {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
+            gap: var(--space-md);
+            width: 100%;
+            margin-top: var(--space-lg);
+        }
+
+        .halves {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+            gap: var(--space-lg);
+            width: 100%;
+            margin-top: var(--space-lg);
+        }
+
+        .five-col {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(140px, 45%), 1fr));
+            gap: var(--space-sm);
+            width: 100%;
+            margin-top: var(--space-lg);
+        }
+
+        /* Cards */
+        .card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-md);
+            padding: var(--space-md);
+        }
+
+        .card-accent {
+            background: var(--accent-dim);
+            border: 1px solid var(--accent-glow);
+            border-radius: var(--radius-md);
+            padding: var(--space-md);
+        }
+
+        .card h3, .card-accent h3 {
+            font-size: var(--fs-h3);
+            font-weight: 600;
+            margin-bottom: var(--space-xs);
+        }
+
+        .card p, .card-accent p {
+            font-size: var(--fs-body);
+            color: var(--text-mid);
+            line-height: 1.6;
+        }
+
+        /* Code blocks */
+        .code-block {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-md);
+            padding: var(--space-sm) var(--space-md);
+            font-family: 'SF Mono', 'Fira Code', 'Courier New', monospace;
+            font-size: var(--fs-code);
+            line-height: 1.6;
+            white-space: pre;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            margin-top: var(--space-md);
+        }
+
+        .code-block .comment { color: rgba(255,255,255,0.35); }
+        .code-block .keyword { color: var(--accent); }
+        .code-block .string { color: var(--green); }
+        .code-block .func { color: var(--blue); }
+        .code-block .type { color: var(--purple); }
+
+        /* Quote */
+        .quote-block {
+            border-left: 3px solid var(--accent);
+            padding: var(--space-md) var(--space-lg);
+            margin: var(--space-lg) 0;
+            max-width: min(700px, 90vw);
+        }
+
+        .quote-block .quote-text {
+            font-size: var(--fs-h2);
+            font-weight: 500;
+            font-style: italic;
+            line-height: 1.4;
+            color: var(--text);
+        }
+
+        .quote-block .quote-attr {
+            font-size: var(--fs-small);
+            color: var(--text-dim);
+            margin-top: var(--space-sm);
+        }
+
+        /* Timeline */
+        .timeline {
+            position: relative;
+            margin-top: var(--space-lg);
+            width: 100%;
+            max-width: min(800px, 95vw);
+        }
+
+        .timeline::before {
+            content: '';
+            position: absolute;
+            left: clamp(14px, 2vw, 20px);
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: linear-gradient(to bottom, var(--accent), var(--green), var(--blue));
+        }
+
+        .timeline-item {
+            position: relative;
+            padding-left: clamp(40px, 6vw, 56px);
+            margin-bottom: var(--space-lg);
+        }
+
+        .timeline-item::before {
+            content: '';
+            position: absolute;
+            left: clamp(8px, 1.5vw, 14px);
+            top: 6px;
+            width: clamp(12px, 2vw, 14px);
+            height: clamp(12px, 2vw, 14px);
+            border-radius: 50%;
+            border: 2px solid var(--accent);
+            background: var(--bg);
+        }
+
+        .timeline-item.act2::before { border-color: var(--green); }
+        .timeline-item.act3::before { border-color: var(--blue); }
+
+        .timeline-date {
+            font-size: var(--fs-small);
+            color: var(--accent);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .timeline-item.act2 .timeline-date { color: var(--green); }
+        .timeline-item.act3 .timeline-date { color: var(--blue); }
+
+        .timeline-title {
+            font-size: var(--fs-h3);
+            font-weight: 600;
+            margin: var(--space-xs) 0;
+        }
+
+        .timeline-desc {
+            font-size: var(--fs-body);
+            color: var(--text-mid);
+            line-height: 1.5;
+        }
+
+        /* Velocity grid */
+        .velocity-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(160px, 45%), 1fr));
+            gap: var(--space-md);
+            width: 100%;
+            max-width: min(900px, 95vw);
+            margin-top: var(--space-lg);
+        }
+
+        .velocity-stat {
+            text-align: center;
+            padding: var(--space-md);
+        }
+
+        .velocity-number {
+            font-size: clamp(40px, 10vw, 72px);
+            font-weight: 700;
+            letter-spacing: -0.03em;
+            line-height: 1;
+            background: linear-gradient(135deg, var(--accent), #FF9F0A);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .velocity-label {
+            font-size: var(--fs-small);
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-top: var(--space-xs);
+        }
+
+        /* Flow diagram */
+        .flow {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: var(--space-sm);
+            margin-top: var(--space-lg);
+        }
+
+        .flow-step {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: var(--space-xs) var(--space-sm);
+            font-size: var(--fs-body);
+            font-weight: 500;
+            white-space: nowrap;
+        }
+
+        .flow-arrow {
+            font-size: var(--fs-body);
+            color: var(--text-dim);
+        }
+
+        .flow-step.highlight {
+            background: var(--accent-dim);
+            border-color: var(--accent-glow);
+            color: var(--accent);
+        }
+
+        /* Pill/tag */
+        .tag {
+            display: inline-block;
+            background: var(--accent-dim);
+            border: 1px solid var(--accent-glow);
+            border-radius: 100px;
+            padding: 4px 14px;
+            font-size: var(--fs-small);
+            font-weight: 500;
+            color: var(--accent);
+        }
+
+        /* Giant need number */
+        .need-number {
+            font-size: clamp(48px, 14vw, 120px);
+            font-weight: 800;
+            letter-spacing: -0.04em;
+            line-height: 0.9;
+            opacity: 0.15;
+            position: absolute;
+            top: var(--space-md);
+            right: var(--space-md);
+        }
+
+        .need-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-md);
+            padding: var(--space-lg) var(--space-md);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .need-card h3 {
+            font-size: var(--fs-h2);
+            font-weight: 700;
+            margin-bottom: var(--space-xs);
+        }
+
+        .need-card p {
+            font-size: var(--fs-body);
+            color: var(--text-mid);
+            line-height: 1.6;
+            max-width: 85%;
+        }
+
+        /* Module type cards */
+        .module-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: var(--space-sm);
+            text-align: center;
+        }
+
+        .module-card .module-letter {
+            font-size: clamp(24px, 5vw, 36px);
+            font-weight: 800;
+            margin-bottom: 4px;
+        }
+
+        .module-card .module-name {
+            font-size: var(--fs-body);
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .module-card .module-contract {
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            font-size: var(--fs-small);
+            color: var(--text-dim);
+        }
+
+        /* Stage cards */
+        .stage-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-md);
+            padding: var(--space-md);
+        }
+
+        .stage-card .stage-number {
+            font-size: var(--fs-small);
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            margin-bottom: var(--space-xs);
+        }
+
+        .stage-card h3 {
+            font-size: var(--fs-h3);
+            font-weight: 700;
+            margin-bottom: var(--space-xs);
+        }
+
+        .stage-card p {
+            font-size: var(--fs-body);
+            color: var(--text-mid);
+            line-height: 1.5;
+        }
+
+        /* Agent cards */
+        .agent-cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+            gap: var(--space-sm);
+            margin-top: var(--space-md);
+            width: 100%;
+        }
+
+        .agent-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-sm);
+            padding: var(--space-sm);
+        }
+
+        .agent-card .agent-name {
+            font-size: var(--fs-body);
+            font-weight: 600;
+            color: var(--blue);
+            margin-bottom: 4px;
+        }
+
+        .agent-card .agent-role {
+            font-size: var(--fs-small);
+            color: var(--text-dim);
+            line-height: 1.4;
+        }
+
+        /* Glow orb */
+        .glow-orb {
+            position: absolute;
+            border-radius: 50%;
+            filter: blur(80px);
+            opacity: 0.15;
+            pointer-events: none;
+        }
+
+        /* Navigation */
+        .nav {
+            position: fixed;
+            bottom: clamp(16px, 3vw, 24px);
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: clamp(6px, 1vw, 8px);
+            z-index: 100;
+            padding: 8px 12px;
+            background: rgba(0,0,0,0.6);
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+            border-radius: 100px;
+        }
+
+        .nav-dot {
+            width: clamp(6px, 1vw, 8px);
+            height: clamp(6px, 1vw, 8px);
+            border-radius: 50%;
+            background: rgba(255,255,255,0.2);
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .nav-dot.active {
+            background: var(--accent);
+            transform: scale(1.3);
+        }
+
+        @media (hover: none) {
+            .nav-dot { min-width: 12px; min-height: 12px; }
+        }
+
+        .slide-counter {
+            position: fixed;
+            bottom: clamp(16px, 3vw, 24px);
+            right: clamp(16px, 3vw, 24px);
+            font-size: var(--fs-small);
+            color: var(--text-dim);
+            z-index: 100;
+        }
+
+        /* Feature list */
+        .feature-list {
+            list-style: none;
+            margin-top: var(--space-md);
+        }
+
+        .feature-list li {
+            font-size: var(--fs-body);
+            color: var(--text-mid);
+            line-height: 1.7;
+            padding: var(--space-xs) 0;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .feature-list li:last-child { border-bottom: none; }
+
+        .feature-list li::before {
+            content: '\2192';
+            color: var(--accent);
+            margin-right: var(--space-xs);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+
+    <!-- Slide 1: Title -->
+    <div class="slide active center" style="position: relative;">
+        <div class="glow-orb" style="width: 400px; height: 400px; background: var(--accent); top: 20%; right: -100px;"></div>
+        <div class="glow-orb" style="width: 300px; height: 300px; background: var(--blue); bottom: 20%; left: -50px;"></div>
+        <div class="section-label">withamplifier.com</div>
+        <h1 class="headline">Five Days<br>to Ship</h1>
+        <p class="subhead" style="margin-top: var(--space-sm);">
+            How Amplifier built its own developers page<br>
+            <span class="dim">from competitive research to upstream PR</span>
+        </p>
+        <div class="small-text" style="margin-top: var(--space-lg);">February 20 &ndash; 25, 2026</div>
+    </div>
+
+    <!-- Slide 2: The Mission -->
+    <div class="slide center">
+        <div class="section-label">The Mission</div>
+        <h2 class="medium-headline" style="max-width: min(800px, 90vw);">Amplifier needed a page that<br>makes developers <span class="accent">feel the pain</span><br>then shows them the way out</h2>
+        <p class="body-text" style="margin-top: var(--space-sm); text-align: center;">
+            Not a feature list. Not API docs. A narrative &mdash; driven by real competitive research &mdash; built with the framework itself.
+        </p>
+    </div>
+
+    <!-- Slide 3: Act I - High level -->
+    <div class="slide">
+        <div class="section-label" style="color: var(--accent);">Act I &middot; February 20</div>
+        <h2 class="medium-headline">Competitive research<br>and a <span class="accent">narrative framework</span></h2>
+        <p class="body-text">
+            We studied five AI agent frameworks &mdash; their docs, their trade-offs, their gaps. 17 research files later, one clear story emerged.
+        </p>
+        <div class="quote-block" style="margin-top: var(--space-lg);">
+            <div class="quote-text">
+                &ldquo;You need <span class="accent">three things</span> from your AI framework. No one gives you all three.&rdquo;
+            </div>
+            <div class="quote-attr">The hook line that drives the entire page</div>
+        </div>
+        <div class="thirds" style="margin-top: var(--space-lg); max-width: min(900px, 95vw);">
+            <div class="card" style="text-align: left;">
+                <h3 style="color: var(--green);">Composability</h3>
+                <p>Build agents from reusable, swappable pieces</p>
+            </div>
+            <div class="card" style="text-align: left;">
+                <h3 style="color: var(--blue);">Control</h3>
+                <p>Own your agent loop, memory, and every decision point</p>
+            </div>
+            <div class="card" style="text-align: left;">
+                <h3 style="color: var(--purple);">Shareability</h3>
+                <p>Publish and compose capabilities across teams</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 4: Act II - High level -->
+    <div class="slide center">
+        <div class="section-label" style="color: var(--green);">Act II &middot; February 24</div>
+        <h2 class="medium-headline" style="max-width: min(800px, 90vw);">Turning research<br>into a <span class="green">living page</span></h2>
+        <p class="body-text" style="text-align: center;">
+            Multiple implementation sessions. Iterative copy refinement. Layout experiments. The narrative tightened with each pass &mdash; from analytical to visceral.
+        </p>
+        <div style="margin-top: var(--space-lg); max-width: min(600px, 95vw); width: 100;">
+            <div style="background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--space-md); margin-bottom: var(--space-sm);">
+                <div class="small-text" style="color: var(--accent); font-weight: 600; text-transform: uppercase; letter-spacing: 1px; margin-bottom: var(--space-xs);">Research Phase</div>
+                <div class="dim" style="font-size: var(--fs-h3); font-weight: 500; line-height: 1.4;">&ldquo;Competitive analysis of AI agent SDK frameworks&rdquo;</div>
+            </div>
+            <div style="background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--space-md); margin-bottom: var(--space-sm);">
+                <div class="small-text" style="color: var(--green); font-weight: 600; text-transform: uppercase; letter-spacing: 1px; margin-bottom: var(--space-xs);">Iterations</div>
+                <div class="mid" style="font-size: var(--fs-h3); font-weight: 500; line-height: 1.4;">&ldquo;You need three things from your AI framework.&rdquo;</div>
+            </div>
+            <div style="background: var(--accent-dim); border: 1px solid var(--accent-glow); border-radius: var(--radius-md); padding: var(--space-md);">
+                <div class="small-text" style="color: var(--accent); font-weight: 600; text-transform: uppercase; letter-spacing: 1px; margin-bottom: var(--space-xs);">What Shipped</div>
+                <div style="font-size: var(--fs-h3); font-weight: 500; line-height: 1.4;">&ldquo;Build AI Your Way <span class="accent">with Amplifier</span>&rdquo;</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 5: Act III intro -->
+    <div class="slide center" style="position: relative;">
+        <div class="glow-orb" style="width: 500px; height: 500px; background: var(--blue); top: 50%; left: 50%; transform: translate(-50%, -50%);"></div>
+        <div class="section-label" style="color: var(--blue);">Act III &middot; February 25</div>
+        <h2 class="headline" style="max-width: min(800px, 90vw);">What we<br><span class="blue">shipped</span></h2>
+        <p class="subhead" style="margin-top: var(--space-sm);">
+            Four pages. ~1,950 lines of Next.js.<br>
+            <span class="dim">A landing page and three documentation deep-dives.</span>
+        </p>
+    </div>
+
+    <!-- Slide 6: The Hero -->
+    <div class="slide">
+        <div class="section-label" style="color: var(--blue);">Landing Page &middot; Hero</div>
+        <h2 class="medium-headline">&ldquo;Build AI Your Way<br>with <span class="accent">Amplifier</span>&rdquo;</h2>
+        <p class="subhead" style="margin-top: 0; margin-bottom: var(--space-md);">
+            <em class="mid">&ldquo;Compose your modules. Control the details. Share with others.&rdquo;</em>
+        </p>
+        <p class="body-text">
+            The hero leads with a single install command. No signup, no platform lock-in. One line to get started.
+        </p>
+        <div class="code-block" style="max-width: min(600px, 95vw);">
+<span class="comment"># The first thing a developer sees</span>
+<span class="func">uv</span> tool install git+https://github.com/microsoft/amplifier</div>
+        <p class="body-text" style="margin-top: var(--space-lg);">
+            Below the fold, the Three Needs framework opens: <em>&ldquo;You need three things from your AI framework.&rdquo;</em> Each need gets its own section &mdash; giant number, pain point, a &ldquo;With Amplifier&rdquo; solution callout, and a working code example.
+        </p>
+    </div>
+
+    <!-- Slide 7: The Three Needs on the page -->
+    <div class="slide">
+        <div class="section-label" style="color: var(--blue);">Landing Page &middot; Three Needs</div>
+        <h2 class="medium-headline">Each need: <span class="accent">giant number</span>,<br>explanation, working code</h2>
+        <div class="thirds" style="margin-top: var(--space-md);">
+            <div class="need-card">
+                <div class="need-number" style="color: var(--green);">01</div>
+                <h3 style="color: var(--green);">Composability</h3>
+                <p>&ldquo;Need a different provider? Different context management? A different orchestration loop? No problem.&rdquo; YAML showing the full swappable module stack.</p>
+            </div>
+            <div class="need-card">
+                <div class="need-number" style="color: var(--blue);">02</div>
+                <h3 style="color: var(--blue);">Control</h3>
+                <p>&ldquo;The agent loop and memory strategy shouldn't be sealed infrastructure you can observe but never change.&rdquo; A hook that teaches the agent conventions &mdash; <em>don't block, teach.</em></p>
+            </div>
+            <div class="need-card">
+                <div class="need-number" style="color: var(--purple);">03</div>
+                <h3 style="color: var(--purple);">Shareability</h3>
+                <p>&ldquo;Your teammate wants your setup with a few changes. Today that means copying config.&rdquo; With Amplifier: <code style="color: var(--purple);">includes:</code> and override only what's different.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 8: Architecture + Modules -->
+    <div class="slide">
+        <div class="section-label" style="color: var(--blue);">Landing Page &middot; Architecture</div>
+        <h2 class="medium-headline">&ldquo;A kernel at the core.&rdquo;<br><span class="dim" style="font-size: var(--fs-h2);">2,600 lines of Python.</span></h2>
+        <p class="body-text">
+            The architecture section explains Amplifier's kernel philosophy through four mechanism cards &mdash; Session Lifecycle, Module Loading, Event Dispatch, Protocol Enforcement &mdash; then the design principle:
+        </p>
+        <div class="quote-block">
+            <div class="quote-text" style="font-size: var(--fs-h3);">
+                &ldquo;Could two teams want different behavior? Then it's a module, not the kernel.&rdquo;
+            </div>
+        </div>
+        <p class="body-text" style="margin-top: var(--space-md);">
+            Below that: five module types, each replaceable, each with its contract signature:
+        </p>
+        <div class="five-col" style="margin-top: var(--space-md);">
+            <div class="module-card">
+                <div class="module-letter" style="color: var(--green);">P</div>
+                <div class="module-name">Provider</div>
+                <div class="module-contract">complete(req)</div>
+            </div>
+            <div class="module-card">
+                <div class="module-letter" style="color: var(--blue);">O</div>
+                <div class="module-name">Orchestrator</div>
+                <div class="module-contract">execute(...)</div>
+            </div>
+            <div class="module-card">
+                <div class="module-letter" style="color: var(--purple);">T</div>
+                <div class="module-name">Tool</div>
+                <div class="module-contract">execute(input)</div>
+            </div>
+            <div class="module-card">
+                <div class="module-letter" style="color: var(--orange);">H</div>
+                <div class="module-name">Hook</div>
+                <div class="module-contract">(event) &rarr; HookResult</div>
+            </div>
+            <div class="module-card">
+                <div class="module-letter" style="color: var(--teal);">C</div>
+                <div class="module-name">Context</div>
+                <div class="module-contract">add/get/set</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 9: Understand / Use / Make It Yours -->
+    <div class="slide">
+        <div class="section-label" style="color: var(--blue);">Landing Page &middot; Developer Journey</div>
+        <h2 class="medium-headline">&ldquo;The Experimental Layer&rdquo;<br><span class="accent">Understand it. Use it. Make it yours.</span></h2>
+        <p class="body-text">
+            The page's second half is a developer funnel &mdash; three stages from comprehension to ownership, backed by fully-built documentation pages.
+        </p>
+        <div class="thirds" style="margin-top: var(--space-md);">
+            <div class="stage-card">
+                <div class="stage-number" style="color: var(--green);">Stage 1</div>
+                <h3>Understand it</h3>
+                <p>Three concept cards link to <strong>full documentation routes</strong>: The Core (sessions, initialize, execute), The Modules (5 protocols, mounting, resolution), The Foundation (bundles, composition, prepare/create). Each with code blocks, ASCII diagrams, and TOC navigation.</p>
+            </div>
+            <div class="stage-card">
+                <div class="stage-number" style="color: var(--blue);">Stage 2</div>
+                <h3>Use it</h3>
+                <p>Three experiment cards linking to real source on GitHub: inject a hook (Hooks API), swap a provider (Provider contract), replace the loop (Orchestrator contract). Hands-on from day one.</p>
+            </div>
+            <div class="stage-card">
+                <div class="stage-number" style="color: var(--purple);">Stage 3</div>
+                <h3>Make it yours</h3>
+                <p>Two paths: build your app with AmplifierSession (Python), or automate with recipes (YAML with staged approval gates). From user to contributor.</p>
+            </div>
+        </div>
+        <p class="small-text" style="margin-top: var(--space-lg);">
+            Final CTA: &ldquo;Try a reference implementation. The Amplifier CLI.&rdquo; &mdash; install command + View on GitHub
+        </p>
+    </div>
+
+    <!-- Slide 10: The Three Documentation Pages -->
+    <div class="slide">
+        <div class="section-label" style="color: var(--blue);">Documentation Pages</div>
+        <h2 class="medium-headline">Three pages that let developers<br><span class="accent">read the source</span></h2>
+        <p class="body-text">
+            Each &ldquo;Understand it&rdquo; card links to a full documentation page with code blocks, ASCII architecture diagrams, reference tables, and TOC navigation. ~1,070 lines across the three routes.
+        </p>
+        <div class="thirds" style="margin-top: var(--space-md);">
+            <div class="card">
+                <h3 style="color: var(--green);">/developers/core</h3>
+                <p style="font-size: var(--fs-small); margin-bottom: var(--space-xs);"><span class="dim">328 lines &middot; 6 sections</span></p>
+                <ul class="feature-list" style="margin-top: var(--space-xs);">
+                    <li>Session lifecycle and config</li>
+                    <li>What initialize() does</li>
+                    <li>What execute() does</li>
+                    <li>The Coordinator's slots</li>
+                </ul>
+            </div>
+            <div class="card">
+                <h3 style="color: var(--blue);">/developers/modules</h3>
+                <p style="font-size: var(--fs-small); margin-bottom: var(--space-xs);"><span class="dim">368 lines &middot; 6 sections</span></p>
+                <ul class="feature-list" style="margin-top: var(--space-xs);">
+                    <li>All five protocols</li>
+                    <li>How modules get found</li>
+                    <li>How a module gets mounted</li>
+                    <li>Existing module catalog</li>
+                </ul>
+            </div>
+            <div class="card">
+                <h3 style="color: var(--purple);">/developers/foundation</h3>
+                <p style="font-size: var(--fs-small); margin-bottom: var(--space-xs);"><span class="dim">374 lines &middot; 7 sections</span></p>
+                <ul class="feature-list" style="margin-top: var(--space-xs);">
+                    <li>What prepare() and create_session() do</li>
+                    <li>How Foundation connects to kernel</li>
+                    <li>Bundle composition rules</li>
+                    <li>Do you even need Foundation?</li>
+                </ul>
+            </div>
+        </div>
+        <p class="small-text" style="margin-top: var(--space-lg);">
+            Supported by 6 reusable doc components: DocCodeBlock, DocDiagram, DocTable, DocSection, DocPagination, DocNote
+        </p>
+    </div>
+
+    <!-- Slide 11: Built With Amplifier -->
+    <div class="slide">
+        <div class="section-label">Built With Amplifier</div>
+        <h2 class="medium-headline">The framework designed<br><span class="blue">its own pages</span></h2>
+        <p class="body-text">
+            All four pages were built using Amplifier's own agents &mdash; from initial research analysis to final layout, component design, and documentation authoring. Dogfooding at its most literal.
+        </p>
+        <div class="agent-cards">
+            <div class="agent-card">
+                <div class="agent-name">session-analyst</div>
+                <div class="agent-role">Mined 7 sessions across 4 projects to extract the story arc you're watching right now</div>
+            </div>
+            <div class="agent-card">
+                <div class="agent-name">layout-architect</div>
+                <div class="agent-role">Page structure, 12-section information hierarchy, alternating light/dark flow</div>
+            </div>
+            <div class="agent-card">
+                <div class="agent-name">component-designer</div>
+                <div class="agent-role">Architecture diagrams, module cards, code panels, interactive elements</div>
+            </div>
+            <div class="agent-card">
+                <div class="agent-name">explorer</div>
+                <div class="agent-role">Codebase survey, research file analysis, cross-session artifact tracking</div>
+            </div>
+        </div>
+        <div class="flow" style="margin-top: var(--space-lg);">
+            <div class="flow-step">Research</div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-step">Narrative</div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-step">Iterations</div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-step highlight">Design Agents</div>
+            <div class="flow-arrow">&rarr;</div>
+            <div class="flow-step">Ship</div>
+        </div>
+    </div>
+
+    <!-- Slide 11: The Journey Timeline -->
+    <div class="slide">
+        <div class="section-label">The Journey</div>
+        <h2 class="medium-headline">Five days, three acts,<br><span class="accent">four shipped pages</span></h2>
+        <div class="timeline">
+            <div class="timeline-item">
+                <div class="timeline-date">Feb 20 &middot; Act I</div>
+                <div class="timeline-title">Research &amp; Narrative</div>
+                <div class="timeline-desc">Surveyed 5 AI agent SDKs. Developed the &ldquo;Three Needs&rdquo; framework: Composability, Control, Shareability.</div>
+            </div>
+            <div class="timeline-item act2">
+                <div class="timeline-date">Feb 24 &middot; Act II</div>
+                <div class="timeline-title">Iteration</div>
+                <div class="timeline-desc">Multiple implementation sessions turning research into a live page. Copy refined from analytical to visceral across each pass.</div>
+            </div>
+            <div class="timeline-item act3">
+                <div class="timeline-date">Feb 25 &middot; Act III</div>
+                <div class="timeline-title">What Shipped</div>
+                <div class="timeline-desc">Full page rebuild with Amplifier's design agents. 880-line landing page plus three deep-dive documentation routes (Core, Modules, Foundation). ~1,950 lines total across 4 routes.</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 12: The Numbers -->
+    <div class="slide center">
+        <div class="section-label">By the Numbers</div>
+        <h2 class="medium-headline">Development velocity</h2>
+        <div class="velocity-grid">
+            <div class="velocity-stat">
+                <div class="velocity-number">7</div>
+                <div class="velocity-label">Sessions</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">5</div>
+                <div class="velocity-label">Days</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">~1,950</div>
+                <div class="velocity-label">Lines Shipped</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">4</div>
+                <div class="velocity-label">Routes</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">5</div>
+                <div class="velocity-label">SDKs Analyzed</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">17</div>
+                <div class="velocity-label">Research Files</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">12</div>
+                <div class="velocity-label">Page Sections</div>
+            </div>
+            <div class="velocity-stat">
+                <div class="velocity-number">3</div>
+                <div class="velocity-label">Doc Sub-Pages</div>
+            </div>
+        </div>
+        <p class="small-text" style="margin-top: var(--space-lg);">4 projects &middot; 1 upstream PR &middot; Built entirely with Amplifier</p>
+    </div>
+
+    <!-- Slide 13: The Meta Story -->
+    <div class="slide center" style="position: relative;">
+        <div class="glow-orb" style="width: 500px; height: 500px; background: var(--accent); top: 50%; left: 50%; transform: translate(-50%, -50%);"></div>
+        <div class="section-label">The Meta Story</div>
+        <h2 class="headline" style="max-width: min(800px, 90vw);">
+            Amplifier built<br><span class="accent">its own story</span>
+        </h2>
+        <p class="subhead" style="margin-top: var(--space-md); max-width: min(650px, 90vw);">
+            The framework that promises composability, control, and shareability &mdash; used all three to build the page that explains them.
+        </p>
+        <div class="thirds" style="margin-top: var(--space-lg); max-width: min(800px, 95vw);">
+            <div class="card" style="text-align: left;">
+                <h3 style="color: var(--green);">Composability</h3>
+                <p>Design agents composed into a research &rarr; narrative &rarr; implementation pipeline</p>
+            </div>
+            <div class="card" style="text-align: left;">
+                <h3 style="color: var(--blue);">Control</h3>
+                <p>7 sessions of human-AI iteration, refining every copy line and layout decision</p>
+            </div>
+            <div class="card" style="text-align: left;">
+                <h3 style="color: var(--purple);">Shareability</h3>
+                <p>Upstream PR to the community website, open-source by default</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Slide 14: CTA -->
+    <div class="slide center">
+        <div class="section-label">See It Live</div>
+        <h2 class="headline">withamplifier.com<span class="accent">/developers</span></h2>
+        <p class="subhead" style="margin-top: var(--space-md);">
+            From competitive research to shipped page.<br>
+            <span class="dim">Built with the framework it describes.</span>
+        </p>
+        <div style="margin-top: var(--space-xl); display: flex; flex-wrap: wrap; gap: var(--space-sm); justify-content: center;">
+            <div class="tag">7 sessions</div>
+            <div class="tag">5 days</div>
+            <div class="tag">~1,950 lines</div>
+            <div class="tag">4 routes</div>
+        </div>
+        <p class="small-text" style="margin-top: var(--space-xl);">
+            Built with Amplifier &middot; February 2026
+        </p>
+    </div>
+
+    <!-- Navigation -->
+    <div class="nav" id="nav"></div>
+    <div class="slide-counter" id="counter"></div>
+
+    <script>
+        const slides = document.querySelectorAll('.slide');
+        let currentSlide = 0;
+
+        function showSlide(n) {
+            slides[currentSlide].classList.remove('active');
+            currentSlide = (n + slides.length) % slides.length;
+            slides[currentSlide].classList.add('active');
+            slides[currentSlide].scrollTop = 0;
+            updateNav();
+        }
+
+        function updateNav() {
+            const nav = document.getElementById('nav');
+            const counter = document.getElementById('counter');
+            nav.innerHTML = '';
+            slides.forEach((_, i) => {
+                const dot = document.createElement('div');
+                dot.className = 'nav-dot' + (i === currentSlide ? ' active' : '');
+                dot.onclick = (e) => { e.stopPropagation(); showSlide(i); };
+                nav.appendChild(dot);
+            });
+            counter.textContent = `${currentSlide + 1} / ${slides.length}`;
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); showSlide(currentSlide + 1); }
+            if (e.key === 'ArrowLeft') { e.preventDefault(); showSlide(currentSlide - 1); }
+        });
+
+        // Click navigation
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('.nav') || e.target.closest('a') || e.target.closest('code')) return;
+            if (e.clientX > window.innerWidth / 2) showSlide(currentSlide + 1);
+            else showSlide(currentSlide - 1);
+        });
+
+        // Touch/swipe navigation
+        let touchStartX = 0;
+        let touchEndX = 0;
+        const SWIPE_THRESHOLD = 50;
+
+        document.addEventListener('touchstart', (e) => {
+            touchStartX = e.changedTouches[0].screenX;
+        }, { passive: true });
+
+        document.addEventListener('touchend', (e) => {
+            touchEndX = e.changedTouches[0].screenX;
+            const diff = touchStartX - touchEndX;
+            if (Math.abs(diff) > SWIPE_THRESHOLD) {
+                if (diff > 0) showSlide(currentSlide + 1);
+                else showSlide(currentSlide - 1);
+            }
+        }, { passive: true });
+
+        updateNav();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds HTML slide deck: **"Five Days to Ship — Building the withamplifier.com Developers Page"**
- Tells the story of how Amplifier built its own developers page over 5 days (Feb 20–25, 2026) — from competitive research through 5 AI agent SDKs, developing the "Three Needs" narrative framework (Composability, Control, Shareability), iterating through multiple implementations, and shipping 4 pages (~1,950 lines of Next.js) including 3 full documentation deep-dives
- The meta angle: **Amplifier built the page that explains Amplifier**

## Details

- **File:** `presentations/withamplifier-developers-page-story.html`
- **Format:** Self-contained HTML slide deck (42KB, 1029 lines)
- **Timeline covered:** Feb 20–25, 2026

## Test plan

- [x] HTML file opens correctly in browser
- [x] Slide navigation works (arrow keys / click)
- [x] Placed in `presentations/` alongside existing story decks

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)