### PR TITLE
refactor: restructure as thin bundle per Amplifier conventions (v3.0.0)

### DIFF
--- a/ACTIVATION.md
+++ b/ACTIVATION.md
@@ -1,26 +1,40 @@
 # Bundle Activation Guide
 
-This bundle has been renamed from `amplifier-stories` to `amplifier-module-stories`.
+**As of v3.0.0, this bundle is named `stories`** (renamed from `amplifier-module-stories` — the `amplifier-module-*` prefix is reserved for Python kernel modules; bundles use short names per Amplifier convention).
 
 ## Update Your Settings
 
-Edit `~/.amplifier/settings.yaml` and change:
+If you were previously using this bundle under its old name, edit `~/.amplifier/settings.yaml`:
 
 ```yaml
 bundle:
-  active: amplifier-stories  # OLD
+  active: amplifier-module-stories  # OLD (pre-v3.0.0)
 ```
 
-To:
+Change to:
 
 ```yaml
 bundle:
-  active: amplifier-module-stories  # NEW
+  active: stories  # NEW (v3.0.0+)
+```
+
+## First-Time Activation
+
+Add to `~/.amplifier/settings.yaml`:
+
+```yaml
+bundle:
+  active: stories
+```
+
+Or load directly from the git repository:
+
+```yaml
+bundle:
+  active: git+https://github.com/ramparte/amplifier-stories@master
 ```
 
 ## Restart Amplifier
-
-After updating settings.yaml:
 
 ```bash
 # Exit current session
@@ -35,46 +49,42 @@ amplifier
 In the new session, run:
 
 ```
-"list available agents"
+list available agents
 ```
 
-You should see 11 agents:
-- storyteller (legacy, still works)
-- story-researcher
-- content-strategist
-- technical-writer
-- marketing-writer
-- executive-briefer
-- release-manager
-- case-study-writer
-- data-analyst
-- content-adapter
-- community-manager
+You should see 12 agents:
 
-## Alternative: Git URL Activation
+| Agent | Purpose |
+|-------|---------|
+| `storyteller` | HTML/PDF presentation decks (canonical renderer) |
+| `storyteller2` | YAML-first deck creation via deck engine |
+| `story-researcher` | Research across session transcripts |
+| `content-strategist` | Strategic content planning |
+| `technical-writer` | Long-form technical documentation |
+| `marketing-writer` | Marketing copy, case studies, landing pages |
+| `executive-briefer` | Executive briefings and status reports |
+| `release-manager` | Release notes and changelogs |
+| `case-study-writer` | Structured case-study format |
+| `data-analyst` | Data narratives from metrics/sessions |
+| `content-adapter` | Converting content across formats |
+| `community-manager` | Blog posts, weekly digests, social posts |
 
-If you want to keep the local development setup:
+## Migration Notes for v3.0.0
 
-```yaml
-bundle:
-  active: git+file:///Users/michaeljabbour/dev/amplifier-stories@master
-```
-
-This loads from your local git repository directly.
+If you have existing bundles, recipes, or sessions that reference `@amplifier-module-stories:`, update them to `@stories:`. The repository URL is unchanged — only the bundle's internal name and namespace have changed.
 
 ## Troubleshooting
 
 **"Bundle not found" error:**
-- Check settings.yaml has correct bundle name
-- Verify amplifier-module-stories is the active bundle
-- Try git URL method if local path issues
+- Check `settings.yaml` has `active: stories` (not the old name)
+- Verify the bundle is discoverable in your configured bundle paths
+- Try the git URL method if local-path resolution is failing
 
 **"Agents not loading" error:**
-- Restart Amplifier session after settings change
-- Check bundle.md has all agent paths correct
-- Run "list available agents" to verify
+- Restart Amplifier after changing `settings.yaml`
+- Run `list available agents` to confirm the 12 agents appear
+- Check that `behaviors/stories.yaml` is intact (it's the single source of truth for agent declarations as of v3.0.0)
 
 **"Skills not found" error:**
-- Verify ~/dev/anthropic-skills is cloned
-- Check skills.dirs in settings.yaml
+- Verify your skills directory configuration in `settings.yaml`
 - Restart after adding skills configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the amplifier-stories bundle will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] — 2026-04-22
+
+### Changed (BREAKING)
+- **Bundle namespace renamed from `amplifier-module-stories` to `stories`.** All `@amplifier-module-stories:` references must be updated to `@stories:` by consumers. The `amplifier-module-*` prefix is reserved for kernel modules; bundles use short names per Amplifier convention (see amplifier-bundle-recipes for the canonical example).
+- **Restructured as thin bundle.** Agents, recipes, and context now declared in `behaviors/stories.yaml` rather than inline in `bundle.md`. The root bundle includes the behavior, which is the single source of truth. External bundles can compose just the behavior without the full root bundle.
+- **Added explicit dependency on `amplifier-foundation`.** Previously the `includes:` block was empty; the bundle now correctly declares its foundation dependency.
+
+### Added
+- `behaviors/stories.yaml` — capability manifest composing 12 agents, 4 recipes, and the awareness context.
+- `context/stories-awareness.md` — delegation pointer injected into parent sessions when the behavior is composed.
+
+### Migration
+External bundles or sessions that reference this bundle must update:
+1. Git URL references and include paths (if any) — no change needed; repo URL is unchanged.
+2. All `@amplifier-module-stories:` @mentions → `@stories:`.
+3. If previously importing individual agents from `bundle.md`, they can now import `stories:behaviors/stories` to get the full capability.
+
 ## [1.0.0] - 2026-01-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Update your `~/.amplifier/settings.yaml` to use this bundle:
 
 ```yaml
 bundle:
-  active: amplifier-module-stories
+  active: stories
 ```
 
 **Note:** Despite "module" in the name, this is an Amplifier **bundle** (not a module). Bundles provide agents, recipes, and behaviors. The name reflects its role as a storytelling capability for the module ecosystem.
@@ -103,13 +103,13 @@ Once the bundle is active, test in a new Amplifier session with these prompts:
 
 ### Test 2: Manual Content Creation
 ```
-"Use storyteller to create a PowerPoint slide using the title template about testing amplifier-module-stories"
+"Use storyteller to create a PowerPoint slide using the title template about testing stories"
 ```
 **Expected:** Single PowerPoint slide created and auto-opened
 
 ### Test 3: Story Research
 ```
-"Use story-researcher to gather data about the amplifier-module-stories repository"
+"Use story-researcher to gather data about the stories repository"
 ```
 **Expected:** Structured JSON with repository metrics, commits, timeline
 
@@ -127,12 +127,12 @@ Once the bundle is active, test in a new Amplifier session with these prompts:
 
 > **Note:** When running recipes via CLI, use the `@` prefix for bundle paths:
 > ```bash
-> amplifier tool invoke recipes operation=execute recipe_path="@amplifier-module-stories:recipes/blog-post-generator.yaml"
+> amplifier tool invoke recipes operation=execute recipe_path="@stories:recipes/blog-post-generator.yaml"
 > ```
 
 ### Test 6: Multi-Format Storytelling
 ```
-"Create a PowerPoint, Excel dashboard, and PDF one-pager about amplifier-module-stories capabilities"
+"Create a PowerPoint, Excel dashboard, and PDF one-pager about stories capabilities"
 ```
 **Expected:** Three files created in parallel, all auto-opened
 
@@ -426,20 +426,20 @@ When invoking recipes programmatically (via CLI or tool calls), use the `@` pref
 ```bash
 # Correct - with @ prefix
 amplifier tool invoke recipes operation=execute \
-  recipe_path="@amplifier-module-stories:recipes/blog-post-generator.yaml"
+  recipe_path="@stories:recipes/blog-post-generator.yaml"
 
 # Wrong - won't work (missing @ prefix)
 amplifier tool invoke recipes operation=execute \
-  recipe_path="amplifier-module-stories:recipes/blog-post-generator.yaml"
+  recipe_path="stories:recipes/blog-post-generator.yaml"
 ```
 
 **Available recipes:**
 | Recipe | Path |
 |--------|------|
-| Session to Case Study | `@amplifier-module-stories:recipes/session-to-case-study.yaml` |
-| Git Tag to Changelog | `@amplifier-module-stories:recipes/git-tag-to-changelog.yaml` |
-| Weekly Digest | `@amplifier-module-stories:recipes/weekly-digest.yaml` |
-| Blog Post Generator | `@amplifier-module-stories:recipes/blog-post-generator.yaml` |
+| Session to Case Study | `@stories:recipes/session-to-case-study.yaml` |
+| Git Tag to Changelog | `@stories:recipes/git-tag-to-changelog.yaml` |
+| Weekly Digest | `@stories:recipes/weekly-digest.yaml` |
+| Blog Post Generator | `@stories:recipes/blog-post-generator.yaml` |
 
 **In conversational mode**, you can use natural language and the `@` prefix is handled automatically:
 ```
@@ -451,7 +451,7 @@ amplifier tool invoke recipes operation=execute \
 
 ### Recipe Path Not Found
 If you get "Recipe file not found" errors:
-1. Ensure you're using the `@` prefix: `@amplifier-module-stories:recipes/...`
+1. Ensure you're using the `@` prefix: `@stories:recipes/...`
 2. Use absolute paths if bundle resolution fails: `$(pwd)/recipes/recipe-name.yaml`
 3. Verify the bundle is active: `amplifier bundle list`
 

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -4,7 +4,7 @@ Complete guide to using the autonomous storytelling engine.
 
 ## Overview
 
-**amplifier-module-stories** transforms Amplifier development activity into professional content across multiple formats and audiences - automatically.
+**stories** transforms Amplifier development activity into professional content across multiple formats and audiences - automatically.
 
 ## Quick Start
 
@@ -25,21 +25,21 @@ Run workflows that generate content automatically:
 ```bash
 # Weekly ecosystem digest (every Monday)
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/weekly-digest.yaml
+  recipe_path=stories:recipes/weekly-digest.yaml
 
 # Generate case study from session
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/session-to-case-study.yaml \
+  recipe_path=stories:recipes/session-to-case-study.yaml \
   context='{"session_file": "~/.amplifier/sessions/2026-01-17/events.jsonl"}'
 
 # Release documentation from git tag
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/git-tag-to-changelog.yaml \
+  recipe_path=stories:recipes/git-tag-to-changelog.yaml \
   context='{"tag_name": "v2.0.0"}'
 
 # Blog post from feature development
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/blog-post-generator.yaml \
+  recipe_path=stories:recipes/blog-post-generator.yaml \
   context='{"feature_name": "shadow environments"}'
 ```
 
@@ -229,7 +229,7 @@ amplifier tool invoke recipes operation=execute \
 **Example:**
 ```bash
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/session-to-case-study.yaml \
+  recipe_path=stories:recipes/session-to-case-study.yaml \
   context='{"session_file": "~/.amplifier/sessions/2026-01-17/events.jsonl"}'
 ```
 
@@ -259,7 +259,7 @@ amplifier tool invoke recipes operation=execute \
 **Example:**
 ```bash
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/git-tag-to-changelog.yaml \
+  recipe_path=stories:recipes/git-tag-to-changelog.yaml \
   context='{"tag_name": "v2.0.0"}'
 ```
 
@@ -289,18 +289,18 @@ amplifier tool invoke recipes operation=execute \
 ```bash
 # Standard weekly digest
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/weekly-digest.yaml
+  recipe_path=stories:recipes/weekly-digest.yaml
 
 # Last 2 weeks
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/weekly-digest.yaml \
+  recipe_path=stories:recipes/weekly-digest.yaml \
   context='{"date_range": "last 14 days"}'
 ```
 
 **Automation:**
 ```cron
 # Every Monday at 9am
-0 9 * * 1 cd ~/dev/amplifier-module-stories && amplifier tool invoke recipes operation=execute recipe_path=./recipes/weekly-digest.yaml
+0 9 * * 1 cd ~/dev/stories && amplifier tool invoke recipes operation=execute recipe_path=./recipes/weekly-digest.yaml
 ```
 
 ---
@@ -330,12 +330,12 @@ amplifier tool invoke recipes operation=execute \
 ```bash
 # Community-focused blog post
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/blog-post-generator.yaml \
+  recipe_path=stories:recipes/blog-post-generator.yaml \
   context='{"feature_name": "shadow environments"}'
 
 # Technical deep-dive with appendix
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/blog-post-generator.yaml \
+  recipe_path=stories:recipes/blog-post-generator.yaml \
   context='{"feature_name": "recipe workflows", "include_technical_appendix": true, "target_audience": "technical"}'
 ```
 
@@ -520,7 +520,7 @@ Start with one format, adapt to others:
 ## File Organization
 
 ```
-amplifier-module-stories/
+stories/
 ├── agents/                   # 10 specialist agents + storyteller
 ├── recipes/                  # 4 automated workflows
 ├── context/
@@ -584,7 +584,7 @@ Should create a single slide, auto-open in PowerPoint.
 ```bash
 # Test with a real session
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/session-to-case-study.yaml \
+  recipe_path=stories:recipes/session-to-case-study.yaml \
   context='{"session_file": "~/.amplifier/sessions/LATEST/events.jsonl"}'
 ```
 

--- a/agents/case-study-writer.md
+++ b/agents/case-study-writer.md
@@ -253,4 +253,4 @@ Case study is successful when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/community-manager.md
+++ b/agents/community-manager.md
@@ -273,4 +273,4 @@ Community content succeeds when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/content-adapter.md
+++ b/agents/content-adapter.md
@@ -213,4 +213,4 @@ Adaptation is successful when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/content-strategist.md
+++ b/agents/content-strategist.md
@@ -196,4 +196,4 @@ Strategy is complete when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/data-analyst.md
+++ b/agents/data-analyst.md
@@ -216,4 +216,4 @@ Data analysis is successful when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/executive-briefer.md
+++ b/agents/executive-briefer.md
@@ -191,4 +191,4 @@ Executive content succeeds when:
 
 ---
 
-@amplifier-module-stories:context/powerpoint-template.md
+@stories:context/powerpoint-template.md

--- a/agents/marketing-writer.md
+++ b/agents/marketing-writer.md
@@ -198,4 +198,4 @@ Marketing content is successful when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/release-manager.md
+++ b/agents/release-manager.md
@@ -245,4 +245,4 @@ Release documentation is complete when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/story-researcher.md
+++ b/agents/story-researcher.md
@@ -232,4 +232,4 @@ Research is complete when:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/storyteller.md
+++ b/agents/storyteller.md
@@ -173,7 +173,7 @@ a PPTX copy.
    Copy templates, rename to slide-01.html, slide-02.html, etc., modify content only.
 
 2. **Read style specification**:
-   - Template reference: `@amplifier-module-stories:context/powerpoint-template.md`
+   - Template reference: `@stories:context/powerpoint-template.md`
 
 3. **Create HTML slides** in `workspace/pptx/html-slides/`:
    - Copy appropriate template from `workspace/pptx/templates/`
@@ -303,7 +303,7 @@ When creating PDFs or processing existing PDFs:
 
 ## Presentation Style: "Useful Apple Keynote"
 
-@amplifier-module-stories:context/presentation-styles.md
+@stories:context/presentation-styles.md
 
 ## Deck Structure
 
@@ -442,4 +442,4 @@ Before finalizing any deck, mentally test every slide at 50% brightness (simulat
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md

--- a/agents/storyteller2.md
+++ b/agents/storyteller2.md
@@ -80,7 +80,7 @@ When asked to "create a story2 deck about X" or "tell a story about X using stor
 
 ## YAML Schema Reference
 
-@amplifier-module-stories:context/storyteller2-instructions.md
+@stories:context/storyteller2-instructions.md
 
 ## Antagonistic Review Checklist
 

--- a/agents/technical-writer.md
+++ b/agents/technical-writer.md
@@ -153,4 +153,4 @@ Technical documentation is complete when:
 
 ---
 
-@amplifier-module-stories:context/powerpoint-template.md
+@stories:context/powerpoint-template.md

--- a/behaviors/stories.yaml
+++ b/behaviors/stories.yaml
@@ -1,0 +1,30 @@
+bundle:
+  name: behavior-stories
+  version: 1.0.0
+  description: Storytelling capability — specialist agents for case studies, presentations, blog posts, release notes, and related content formats.
+
+agents:
+  include:
+    - stories:agents/storyteller
+    - stories:agents/storyteller2
+    - stories:agents/story-researcher
+    - stories:agents/content-strategist
+    - stories:agents/technical-writer
+    - stories:agents/marketing-writer
+    - stories:agents/executive-briefer
+    - stories:agents/release-manager
+    - stories:agents/case-study-writer
+    - stories:agents/data-analyst
+    - stories:agents/content-adapter
+    - stories:agents/community-manager
+
+recipes:
+  include:
+    - stories:recipes/session-to-case-study
+    - stories:recipes/git-tag-to-changelog
+    - stories:recipes/weekly-digest
+    - stories:recipes/blog-post-generator
+
+context:
+  include:
+    - stories:context/stories-awareness.md

--- a/bundle.md
+++ b/bundle.md
@@ -1,51 +1,13 @@
 ---
 bundle:
-  name: amplifier-module-stories
-  version: 2.0.0
+  name: stories
+  version: 3.0.0
   description: Autonomous storytelling engine for the Amplifier ecosystem - automated content generation across formats and audiences
 
 includes:
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main
+  - bundle: stories:behaviors/stories
 
-agents:
-  # Legacy agent (maintained for backward compatibility)
-  storyteller:
-    path: amplifier-module-stories:agents/storyteller.md
-
-  # Story2: YAML-first deck creation via deck engine
-  storyteller2:
-    path: amplifier-module-stories:agents/storyteller2.md
-
-  # Specialist agents for autonomous storytelling
-  story-researcher:
-    path: amplifier-module-stories:agents/story-researcher.md
-  content-strategist:
-    path: amplifier-module-stories:agents/content-strategist.md
-  technical-writer:
-    path: amplifier-module-stories:agents/technical-writer.md
-  marketing-writer:
-    path: amplifier-module-stories:agents/marketing-writer.md
-  executive-briefer:
-    path: amplifier-module-stories:agents/executive-briefer.md
-  release-manager:
-    path: amplifier-module-stories:agents/release-manager.md
-  case-study-writer:
-    path: amplifier-module-stories:agents/case-study-writer.md
-  data-analyst:
-    path: amplifier-module-stories:agents/data-analyst.md
-  content-adapter:
-    path: amplifier-module-stories:agents/content-adapter.md
-  community-manager:
-    path: amplifier-module-stories:agents/community-manager.md
-
-recipes:
-  session-to-case-study:
-    path: amplifier-module-stories:recipes/session-to-case-study.yaml
-  git-tag-to-changelog:
-    path: amplifier-module-stories:recipes/git-tag-to-changelog.yaml
-  weekly-digest:
-    path: amplifier-module-stories:recipes/weekly-digest.yaml
-  blog-post-generator:
-    path: amplifier-module-stories:recipes/blog-post-generator.yaml
 ---
 
 # Amplifier Module: Stories
@@ -125,7 +87,7 @@ Then deploy with:
 
 ---
 
-@amplifier-module-stories:context/storyteller-instructions.md
+@stories:context/storyteller-instructions.md
 
 ---
 

--- a/context/stories-awareness.md
+++ b/context/stories-awareness.md
@@ -1,0 +1,40 @@
+# Stories Capability
+
+You have access to the `stories` bundle for creating content from Amplifier sessions, projects, and work artifacts.
+
+## When to Use
+
+Delegate to the stories agents when the user wants to:
+- Turn a session into a case study, blog post, or executive briefing
+- Generate release notes, weekly digests, or changelogs
+- Produce HTML presentation decks or PDF handouts
+- Adapt existing content across formats or audiences
+
+## Agent Dispatch
+
+| Task | Agent |
+|------|-------|
+| HTML/PDF presentation decks (canonical renderer) | `stories:storyteller` |
+| YAML-first deck creation via deck engine | `stories:storyteller2` |
+| Research across session transcripts for narrative material | `stories:story-researcher` |
+| Long-form technical documentation | `stories:technical-writer` |
+| Marketing copy, case studies, landing-page content | `stories:marketing-writer` |
+| Executive briefings and status reports | `stories:executive-briefer` |
+| Release notes and changelogs | `stories:release-manager` |
+| Structured case-study format | `stories:case-study-writer` |
+| Data narratives from metrics/sessions | `stories:data-analyst` |
+| Converting content across formats | `stories:content-adapter` |
+| Blog posts, weekly digests, social posts | `stories:community-manager` |
+| Strategic content planning | `stories:content-strategist` |
+
+## Recipes
+
+For multi-step workflows, prefer the recipes in this bundle (see `stories:recipes/`) over ad-hoc orchestration:
+- `session-to-case-study` — turn a session into a case study with approval gates
+- `blog-post-generator` — produce a blog post from a topic prompt
+- `git-tag-to-changelog` — generate release notes from a git tag range
+- `weekly-digest` — summarize a week of work
+
+## Notes
+
+Delegate to specialist agents rather than doing content work inline — they carry format-specific context, style guides, and quality heuristics.

--- a/tests/examples/blog-post-generator-test.md
+++ b/tests/examples/blog-post-generator-test.md
@@ -153,7 +153,7 @@ Blog post opens in default markdown editor.
 ```bash
 # 1. Run the recipe
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/blog-post-generator.yaml \
+  recipe_path=stories:recipes/blog-post-generator.yaml \
   context='{"feature_name": "shadow environments", "target_audience": "community"}'
 
 # 2. Check blog post (should auto-open)

--- a/tests/examples/git-tag-to-changelog-test.md
+++ b/tests/examples/git-tag-to-changelog-test.md
@@ -15,7 +15,7 @@ Repository must have:
 
 ## Test Data
 
-**Tag to test:** Latest tag in amplifier-module-stories repository
+**Tag to test:** Latest tag in stories repository
 
 ```bash
 # Check existing tags
@@ -50,7 +50,7 @@ git tag -a v2.0.0-test -m "Test release"
 - Professional templates for all formats
 
 ### Changed
-- Bundle renamed to amplifier-module-stories
+- Bundle renamed to stories
 - Workspace structure consolidated
 
 ### Fixed
@@ -121,7 +121,7 @@ git tag v2.0.0-test
 
 # 3. Run the recipe
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/git-tag-to-changelog.yaml \
+  recipe_path=stories:recipes/git-tag-to-changelog.yaml \
   context='{"tag_name": "v2.0.0-test"}'
 
 # 4. Verify CHANGELOG.md was updated

--- a/tests/examples/session-to-case-study-test.md
+++ b/tests/examples/session-to-case-study-test.md
@@ -76,7 +76,7 @@ ls -lt ~/.amplifier/sessions/*/events.jsonl | head -5
 
 # 2. Run the recipe
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/session-to-case-study.yaml \
+  recipe_path=stories:recipes/session-to-case-study.yaml \
   context='{"session_file": "~/.amplifier/sessions/2026-01-17/events.jsonl"}'
 
 # 3. Verify output

--- a/tests/examples/weekly-digest-test.md
+++ b/tests/examples/weekly-digest-test.md
@@ -113,7 +113,7 @@ Blog post opens in default markdown editor for review.
 ```bash
 # 1. Run the recipe
 amplifier tool invoke recipes operation=execute \
-  recipe_path=amplifier-module-stories:recipes/weekly-digest.yaml
+  recipe_path=stories:recipes/weekly-digest.yaml
 
 # 2. Check outputs
 ls -lh workspace/blog/
@@ -157,7 +157,7 @@ Can this be run automatically every Monday?
 **Cron example:**
 ```cron
 # Every Monday at 9am
-0 9 * * 1 cd /path/to/amplifier-module-stories && amplifier tool invoke recipes operation=execute recipe_path=./recipes/weekly-digest.yaml
+0 9 * * 1 cd /path/to/stories && amplifier tool invoke recipes operation=execute recipe_path=./recipes/weekly-digest.yaml
 ```
 
 **GitHub Actions example:**


### PR DESCRIPTION
Supersedes #97. Opening as a PR for review rather than waiting on RFC — happy to close, rework, or cherry-pick per your preference.

## Summary

Four structural changes aligning this bundle with canonical Amplifier thin-bundle conventions (as established by `amplifier-bundle-recipes`):

1. **Namespace rename**: `amplifier-module-stories` → `stories`
2. **Thin bundle pattern**: agents/recipes moved into `behaviors/stories.yaml`
3. **Explicit foundation dependency** (previously missing from `includes:`)
4. **Restored `storyteller2`** (accidentally dropped in a prior refactor attempt on my fork)

Diff: ~21 files modified, 2 files created, zero changes to agent instructions, recipe content, tool scripts, or the `docs/`/`presentations/` output trees. The heavy file count is mechanical `@mention` namespace updates; the real structural change is just `bundle.md` + `behaviors/stories.yaml` + `context/stories-awareness.md`.

## Motivation

Consulted the Amplifier foundation-expert on convention alignment. Three issues surfaced:

- `bundle.name: amplifier-module-stories` uses a prefix reserved for Python kernel modules. `amplifier-bundle-recipes` demonstrates the correct pattern: `bundle.name: recipes`. Short names are the norm.
- `includes:` in `bundle.md` was empty — the bundle was running without `amplifier-foundation` composed, meaning no session primitives, tools, or common hooks. Almost certainly unintentional.
- Agents declared inline in `bundle.md` rather than in a `behaviors/` manifest prevents other bundles from composing just the storytelling capability without taking the full root bundle.

## Changes

### `bundle.md`
- `name: amplifier-module-stories` → `stories`
- `version: 2.0.0` → `3.0.0` (breaking namespace change)
- `includes:` — now declares `amplifier-foundation` and `stories:behaviors/stories` using canonical `- bundle: <value>` syntax
- `agents:` and `recipes:` blocks removed — single source of truth moved to the behavior

### New: `behaviors/stories.yaml`
Capability manifest: 12 agents (including `storyteller2`), 4 recipes, and the awareness context. Other bundles can compose `stories:behaviors/stories` to get just the storytelling capability.

### New: `context/stories-awareness.md`
Delegation pointer injected into parent sessions when the behavior is composed. Includes an agent-dispatch table (which agent for which task) so composing sessions don't have to guess.

### Namespace updates
All `@amplifier-module-stories:` → `@stories:` across agents (12 files), `README.md`, `USAGE_GUIDE.md`, `tests/examples/` (4 files), `ACTIVATION.md`.

### `ACTIVATION.md` refresh
Updated to reflect v3 state (removed developer-specific local paths, added the full 12-agent table, added migration guidance).

### `CHANGELOG.md`
New `[3.0.0]` entry documenting the rename + migration path for external consumers.

## What's NOT changed

- Agent `.md` frontmatter, capabilities, tool lists — only the `@mention` namespace within instructions
- Recipe YAML content — same
- `tools/` Python scripts
- `docs/`, `presentations/`, `case-studies/`, `stories/`, `staging/`, `workspace/` trees (published output)
- Repository URL (migration is a one-line sed across consumer references: `s/amplifier-module-stories:/stories:/g`)

## Verification done locally

- Zero leftover `amplifier-module-stories:` strings in live files (historical logs and CHANGELOG migration notes excluded by design)
- `behaviors/stories.yaml` agent count: 12 (including `storyteller2`)
- `bundle.md` frontmatter has no `agents:` or `recipes:` blocks (moved to behavior, no DRY violation)
- `includes:` uses `- bundle: <value>` syntax on both entries

## Questions

1. Any concerns with `stories` as the new short name? (Happy to adjust if you'd prefer e.g. `storytelling`, `amplifier-stories`, etc.)
2. OK with the behavior-file-as-single-source-of-truth pattern, or do you prefer keeping declarations inline in `bundle.md`?
3. If this shape isn't what you want, let me know and I'll close this PR — it's easier for me to rework than for you to adapt 23 files of my opinions.

No urgency from my end. Independent of PR #96 (slide-transition fix) — different files, no conflict.